### PR TITLE
changing the branch for pod installation.

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { "Erik" => "nuclear.ace@gmail.com" }
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
-  s.source       = { :git => "https://github.com/socketio/socket.io-client-swift.git", :tag => 'v1.1.4' }
+  s.source       = { :git => "https://github.com/socketio/socket.io-client-swift.git", :tag => 'v1.1.4', :branch => '1.2' }
   s.source_files  = "SwiftIO/**/*.swift"
   s.requires_arc = true
   # s.dependency 'Starscream', '~> 0.9' # currently this repo includes Starscream swift files


### PR DESCRIPTION
Did not test it, but according to the `http://guides.cocoapods.org/using/the-podfile.html` - this should work.
Fixes socketio/socket.io-client-swift#14