### PR TITLE
Fixed the use of the ?? operator because Swift is broken

### DIFF
--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -366,7 +366,7 @@ public final class SocketIOClient: NSObject, SocketEngineClient, SocketLogClient
         SocketLogger.log("Client: Handling ack: \(ack) with data: \(data)", client: self)
         
         self.ackHandlers.executeAck(ack,
-            items: data as? [AnyObject]? ?? data != nil ? [data!] : nil)
+            items: (data as? [AnyObject]?) ?? (data != nil ? [data!] : nil))
     }
     
     /**


### PR DESCRIPTION
I fixed a strange bug where in `handleAck`, the data would be inclosed in an unnecessary Array because of a bug in swift/Xcode/clang.

When you use the `??` operator in the call to function, it doesn't seem to detect the lack of parenthesis to inform of the desired priority.

This screenshot should help explain:

![screen shot 2015-04-13 at 15 40 43](https://cloud.githubusercontent.com/assets/5111814/7116667/930f93a4-e1f3-11e4-8f76-f5245af193b5.png)

As you can see, line 11 isn't flagged as an error.
Line 13 is my fix by adding parenthesis.
And line 15 generates an error.

![](http://media.giphy.com/media/cEYFeDYAEZ974cOS8CY/giphy.gif)