### PR TITLE
Remove handlers

### DIFF
--- a/Socket.IO-Client-Swift.xcodeproj/xcshareddata/xcschemes/SocketIO-Mac.xcscheme
+++ b/Socket.IO-Client-Swift.xcodeproj/xcshareddata/xcschemes/SocketIO-Mac.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "572EF2371B51F18A00EEBB58"
-               BuildableName = "SocketIO-Mac.framework"
+               BuildableName = "SocketIO.framework"
                BlueprintName = "SocketIO-Mac"
                ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "572EF2371B51F18A00EEBB58"
-            BuildableName = "SocketIO-Mac.framework"
+            BuildableName = "SocketIO.framework"
             BlueprintName = "SocketIO-Mac"
             ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
          </BuildableReference>
@@ -76,7 +76,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "572EF2371B51F18A00EEBB58"
-            BuildableName = "SocketIO-Mac.framework"
+            BuildableName = "SocketIO.framework"
             BlueprintName = "SocketIO-Mac"
             ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
          </BuildableReference>
@@ -94,7 +94,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "572EF2371B51F18A00EEBB58"
-            BuildableName = "SocketIO-Mac.framework"
+            BuildableName = "SocketIO.framework"
             BlueprintName = "SocketIO-Mac"
             ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
          </BuildableReference>

--- a/Socket.IO-Client-Swift.xcodeproj/xcshareddata/xcschemes/SocketIO-iOS.xcscheme
+++ b/Socket.IO-Client-Swift.xcodeproj/xcshareddata/xcschemes/SocketIO-iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "572EF2181B51F16C00EEBB58"
-               BuildableName = "SocketIO-iOS.framework"
+               BuildableName = "SocketIO.framework"
                BlueprintName = "SocketIO-iOS"
                ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "572EF2181B51F16C00EEBB58"
-            BuildableName = "SocketIO-iOS.framework"
+            BuildableName = "SocketIO.framework"
             BlueprintName = "SocketIO-iOS"
             ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
          </BuildableReference>
@@ -76,7 +76,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "572EF2181B51F16C00EEBB58"
-            BuildableName = "SocketIO-iOS.framework"
+            BuildableName = "SocketIO.framework"
             BlueprintName = "SocketIO-iOS"
             ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
          </BuildableReference>
@@ -94,7 +94,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "572EF2181B51F16C00EEBB58"
-            BuildableName = "SocketIO-iOS.framework"
+            BuildableName = "SocketIO.framework"
             BlueprintName = "SocketIO-iOS"
             ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
          </BuildableReference>

--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -448,6 +448,14 @@ public final class SocketIOClient: NSObject, SocketEngineClient, SocketLogClient
         let handler = SocketEventHandler(event: event, callback: callback)
         handlers.append(handler)
     }
+
+	/**
+	Removes all handlers.
+	Can be used after disconnecting to break any potential remaining retain cycles.
+	*/
+	public func removeAllHandlers() {
+		handlers.removeAll(keepCapacity: false)
+	}
     
     /**
     Adds a handler that will be called on every event.


### PR DESCRIPTION
## Changes:

- Updated `BuildableName` in schemes: this is a left over from #117. I updated the product name as `-` are an invalid character, but I forgot to reflect this change in the schemes.
- Added `SocketIOClient.removeAllHandlers`: This is useful after disconnecting, if you won't reconnect again. It would breaks any potential retain cycles. Right now the alternative is doing `client.off("event")` for every handler, which is error prone.