### PR TITLE
Using new Xcode 7 -Owholemodule optimization setting

### DIFF
--- a/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
+++ b/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
@@ -545,7 +545,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = SocketIO;
-				SWIFT_WHOLE_MODULE_OPTIMIZATION = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Whole module optimization is now integrated in `SWIFT_OPTIMIZATION_LEVEL` rather than being a separate setting like before.

This turns in on for Release mode.