### PR TITLE
Code improvements to Swift 2 branch

### DIFF
--- a/SocketIOClientSwift/SocketEngine.swift
+++ b/SocketIOClientSwift/SocketEngine.swift
@@ -350,9 +350,11 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
     // We had packets waiting for send when we upgraded
     // Send them raw
     private func flushWaitingForPostToWebSocket() {
-        for msg in postWait {
-            ws?.writeString(msg)
-        }
+		if let ws = ws {
+			for msg in postWait {
+				ws.writeString(msg)
+			}
+		}
 
         postWait.removeAll(keepCapacity: true)
     }
@@ -495,7 +497,7 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
         var n = 0
         var msg = ""
 
-        func testLength(length:String, inout n:Int) -> Bool {
+        func testLength(length: String, inout n: Int) -> Bool {
             if let num = Int(length) {
                 n = num
                 return false
@@ -525,8 +527,8 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
 
                 if msg.characters.count != 0 {
                     // Be sure to capture the value of the msg
-                    dispatch_async(handleQueue) {[weak self, msg] in
-                        self?.parseEngineMessage(msg, fromPolling: true)
+					dispatch_async(handleQueue) {
+                        self.parseEngineMessage(msg, fromPolling: true)
                     }
                 }
 
@@ -549,8 +551,8 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
 
         let type = PacketType(str: (message["^(\\d)"].groups()?[1]) ?? "") ?? {
             self.checkIfMessageIsBase64Binary(message)
-            return PacketType.Noop
-            }()
+            return .Noop
+		}()
 
         switch type {
         case PacketType.Message:
@@ -608,13 +610,11 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
 
             postWait.append(strMsg)
 
-            if let datas = datas {
-                for data in datas {
-                    let (_, b64Data) = createBinaryDataForSend(data)
+			for data in datas ?? [] {
+				let (_, b64Data) = createBinaryDataForSend(data)
 
-                    postWait.append(b64Data!)
-                }
-            }
+				postWait.append(b64Data!)
+			}
 
             if !waitingForPost {
                 flushWaitingForPost()
@@ -629,30 +629,26 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
 
             ws?.writeString("\(type.rawValue)\(str)")
 
-            if let datas = datas {
-                for data in datas {
-                    let (data, _) = createBinaryDataForSend(data)
-                    if data != nil {
-                        ws?.writeData(data!)
-                    }
-                }
-            }
+			for data in datas ?? [] {
+				let (data, _) = createBinaryDataForSend(data)
+				if data != nil {
+					ws?.writeData(data!)
+				}
+			}
     }
 
     // Starts the ping timer
     private func startPingTimer() {
-        guard pingInterval != nil else {
-            return
-        }
+		if let pingInterval = pingInterval {
+			pingTimer?.invalidate()
+			pingTimer = nil
 
-        pingTimer?.invalidate()
-        dispatch_async(dispatch_get_main_queue()) {[weak self] in
-            if let this = self {
-                this.pingTimer = NSTimer.scheduledTimerWithTimeInterval(this.pingInterval!, target: this,
-                    selector: Selector("sendPing"), userInfo: nil, repeats: true)
-            }
-        }
-    }
+			dispatch_async(dispatch_get_main_queue()) {
+				self.pingTimer = NSTimer.scheduledTimerWithTimeInterval(pingInterval, target: self,
+					selector: Selector("sendPing"), userInfo: nil, repeats: true)
+			}
+		}
+	}
 
     func stopPolling() {
         session.invalidateAndCancel()
@@ -672,16 +668,16 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
     Write a message, independent of transport.
     */
     public func write(msg: String, withType type: PacketType, withData data: [NSData]?) {
-        dispatch_async(emitQueue) {[weak self] in
-            if let this = self where this.connected {
-                if this.websocket {
-                    Logger.log("Writing ws: %@ has data: %@", type: this.logType, args: msg,
+		dispatch_async(emitQueue) {
+            if self.connected {
+                if self.websocket {
+                    Logger.log("Writing ws: %@ has data: %@", type: self.logType, args: msg,
                         data == nil ? false : true)
-                    this.sendWebSocketMessage(msg, withType: type, datas: data)
+                    self.sendWebSocketMessage(msg, withType: type, datas: data)
                 } else {
-                    Logger.log("Writing poll: %@ has data: %@", type: this.logType, args: msg,
+                    Logger.log("Writing poll: %@ has data: %@", type: self.logType, args: msg,
                         data == nil ? false : true)
-                    this.sendPollMessage(msg, withType: type, datas: data)
+                    self.sendPollMessage(msg, withType: type, datas: data)
                 }
             }
         }

--- a/SocketIOClientSwift/SocketEngine.swift
+++ b/SocketIOClientSwift/SocketEngine.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public final class SocketEngine: NSObject, WebSocketDelegate {    
+public final class SocketEngine: NSObject, WebSocketDelegate {
     private typealias Probe = (msg: String, type: PacketType, data: [NSData]?)
     private typealias ProbeWaitQueue = [Probe]
 
@@ -350,11 +350,11 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
     // We had packets waiting for send when we upgraded
     // Send them raw
     private func flushWaitingForPostToWebSocket() {
-		if let ws = ws {
-			for msg in postWait {
-				ws.writeString(msg)
-			}
-		}
+        if let ws = ws {
+            for msg in postWait {
+                ws.writeString(msg)
+            }
+        }
 
         postWait.removeAll(keepCapacity: true)
     }
@@ -527,7 +527,7 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
 
                 if msg.characters.count != 0 {
                     // Be sure to capture the value of the msg
-					dispatch_async(handleQueue) {
+                    dispatch_async(handleQueue) {
                         self.parseEngineMessage(msg, fromPolling: true)
                     }
                 }
@@ -552,7 +552,7 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
         let type = PacketType(str: (message["^(\\d)"].groups()?[1]) ?? "") ?? {
             self.checkIfMessageIsBase64Binary(message)
             return .Noop
-		}()
+            }()
 
         switch type {
         case PacketType.Message:
@@ -610,11 +610,11 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
 
             postWait.append(strMsg)
 
-			for data in datas ?? [] {
-				let (_, b64Data) = createBinaryDataForSend(data)
+            for data in datas ?? [] {
+                let (_, b64Data) = createBinaryDataForSend(data)
 
-				postWait.append(b64Data!)
-			}
+                postWait.append(b64Data!)
+            }
 
             if !waitingForPost {
                 flushWaitingForPost()
@@ -629,26 +629,26 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
 
             ws?.writeString("\(type.rawValue)\(str)")
 
-			for data in datas ?? [] {
-				let (data, _) = createBinaryDataForSend(data)
-				if data != nil {
-					ws?.writeData(data!)
-				}
-			}
+            for data in datas ?? [] {
+                let (data, _) = createBinaryDataForSend(data)
+                if data != nil {
+                    ws?.writeData(data!)
+                }
+            }
     }
 
     // Starts the ping timer
     private func startPingTimer() {
-		if let pingInterval = pingInterval {
-			pingTimer?.invalidate()
-			pingTimer = nil
+        if let pingInterval = pingInterval {
+            pingTimer?.invalidate()
+            pingTimer = nil
 
-			dispatch_async(dispatch_get_main_queue()) {
-				self.pingTimer = NSTimer.scheduledTimerWithTimeInterval(pingInterval, target: self,
-					selector: Selector("sendPing"), userInfo: nil, repeats: true)
-			}
-		}
-	}
+            dispatch_async(dispatch_get_main_queue()) {
+                self.pingTimer = NSTimer.scheduledTimerWithTimeInterval(pingInterval, target: self,
+                    selector: Selector("sendPing"), userInfo: nil, repeats: true)
+            }
+        }
+    }
 
     func stopPolling() {
         session.invalidateAndCancel()
@@ -668,7 +668,7 @@ public final class SocketEngine: NSObject, WebSocketDelegate {
     Write a message, independent of transport.
     */
     public func write(msg: String, withType type: PacketType, withData data: [NSData]?) {
-		dispatch_async(emitQueue) {
+        dispatch_async(emitQueue) {
             if self.connected {
                 if self.websocket {
                     Logger.log("Writing ws: %@ has data: %@", type: self.logType, args: msg,

--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -150,10 +150,13 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     */
     public func connect(timeoutAfter timeoutAfter:Int,
         withTimeoutHandler handler:(() -> Void)?) {
-            guard status != SocketIOClientStatus.Connected else {
+			assert(timeoutAfter >= 0, "Invalid timeout: \(timeoutAfter)")
+
+            guard status != .Connected else {
                 return
             }
-            if status == SocketIOClientStatus.Closed {
+
+            if status == .Closed {
                 Logger.log("Warning! This socket was previously closed. This might be dangerous!",
                     type: logType)
             }

--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -25,10 +25,11 @@
 import Foundation
 
 public final class SocketIOClient: NSObject, SocketEngineClient {
-    public let emitQueue = dispatch_queue_create("emitQueue", DISPATCH_QUEUE_SERIAL)
-    public let handleQueue: dispatch_queue_t!
-    public let socketURL: String
-    
+    private let emitQueue = dispatch_queue_create("emitQueue", DISPATCH_QUEUE_SERIAL)
+    private let handleQueue: dispatch_queue_t!
+
+	public let socketURL: String
+
     public private(set) var engine: SocketEngine?
     public private(set) var secure = false
     public private(set) var status = SocketIOClientStatus.NotConnected
@@ -49,10 +50,11 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     private var connectParams: [String: AnyObject]?
     private var reconnectTimer: NSTimer?
     
-    let reconnectAttempts: Int!
-    var ackHandlers = SocketAckManager()
-    var currentAck = -1
-    var waitingData = [SocketPacket]()
+    private let reconnectAttempts: Int!
+    private var ackHandlers = SocketAckManager()
+    private var currentAck = -1
+
+	internal var waitingData = [SocketPacket]()
     
     /**
     Create a new SocketIOClient. opts can be omitted

--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -114,10 +114,13 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
         engine?.close(fast: true)
     }
     
-    private func addEngine() {
+    private func addEngine() -> SocketEngine {
         Logger.log("Adding engine", type: logType)
-        
-        engine = SocketEngine(client: self, opts: opts)
+
+		let newEngine = SocketEngine(client: self, opts: opts)
+
+        engine = newEngine
+		return newEngine
     }
     
     private func clearReconnectTimer() {
@@ -162,8 +165,7 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
             }
             
             status = SocketIOClientStatus.Connecting
-            addEngine()
-            engine?.open(connectParams)
+            addEngine().open(connectParams)
             
             guard timeoutAfter != 0 else {
                 return

--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -28,7 +28,7 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     private let emitQueue = dispatch_queue_create("emitQueue", DISPATCH_QUEUE_SERIAL)
     private let handleQueue: dispatch_queue_t!
 
-	public let socketURL: String
+    public let socketURL: String
 
     public private(set) var engine: SocketEngine?
     public private(set) var secure = false
@@ -117,10 +117,10 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     private func addEngine() -> SocketEngine {
         Logger.log("Adding engine", type: logType)
 
-		let newEngine = SocketEngine(client: self, opts: opts)
+        let newEngine = SocketEngine(client: self, opts: opts)
 
         engine = newEngine
-		return newEngine
+        return newEngine
     }
     
     private func clearReconnectTimer() {
@@ -153,7 +153,7 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     */
     public func connect(timeoutAfter timeoutAfter:Int,
         withTimeoutHandler handler:(() -> Void)?) {
-			assert(timeoutAfter >= 0, "Invalid timeout: \(timeoutAfter)")
+            assert(timeoutAfter >= 0, "Invalid timeout: \(timeoutAfter)")
 
             guard status != .Connected else {
                 return
@@ -172,9 +172,9 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
             }
             
             let time = dispatch_time(DISPATCH_TIME_NOW, Int64(timeoutAfter) * Int64(NSEC_PER_SEC))
-            
-			dispatch_after(time, dispatch_get_main_queue()) {
-				if self.status != .Connected {
+
+            dispatch_after(time, dispatch_get_main_queue()) {
+                if self.status != .Connected {
                     self.status = .Closed
                     self.engine?.close(fast: true)
                     
@@ -259,8 +259,8 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
         guard status == .Connected else {
             return
         }
-        
-		dispatch_async(emitQueue) {
+
+        dispatch_async(emitQueue) {
             self._emit([event] + items)
         }
     }
@@ -300,7 +300,7 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     // If the server wants to know that the client received data
     func emitAck(ack: Int, withItems items: [AnyObject]) {
         dispatch_async(emitQueue) {
-			if self.status == .Connected {
+            if self.status == .Connected {
                 let packet = SocketPacket.packetFromEmit(items, id: ack ?? -1, nsp: self.nsp, ack: true)
                 let str = packet.packetString
                 
@@ -448,13 +448,13 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     
     public func parseSocketMessage(msg: String) {
         dispatch_async(handleQueue) {
-			SocketParser.parseSocketMessage(msg, socket: self)
+            SocketParser.parseSocketMessage(msg, socket: self)
         }
     }
     
     public func parseBinaryData(data: NSData) {
         dispatch_async(handleQueue) {
-			SocketParser.parseBinaryData(data, socket: self)
+            SocketParser.parseBinaryData(data, socket: self)
         }
     }
     
@@ -472,9 +472,9 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
             
             status = .Reconnecting
             
-			dispatch_async(dispatch_get_main_queue()) {
-				self.reconnectTimer = NSTimer.scheduledTimerWithTimeInterval(Double(self.reconnectWait),
-					target: self, selector: "_tryReconnect", userInfo: nil, repeats: true)
+            dispatch_async(dispatch_get_main_queue()) {
+                self.reconnectTimer = NSTimer.scheduledTimerWithTimeInterval(Double(self.reconnectWait),
+                    target: self, selector: "_tryReconnect", userInfo: nil, repeats: true)
             }
         }
     }

--- a/SocketIOClientSwift/SocketIOClient.swift
+++ b/SocketIOClientSwift/SocketIOClient.swift
@@ -401,7 +401,7 @@ public final class SocketIOClient: NSObject, SocketEngineClient {
     public func off(event: String) {
         Logger.log("Removing handler for event: %@", type: logType, args: event)
         
-        handlers = ContiguousArray(handlers.filter {!($0.event == event)})
+        handlers = ContiguousArray(handlers.filter { $0.event != event })
     }
     
     /**

--- a/SocketIOClientSwift/SocketPacket.swift
+++ b/SocketIOClientSwift/SocketPacket.swift
@@ -28,6 +28,8 @@ struct SocketPacket {
     private let placeholders: Int
     private var currentPlace = 0
 
+	private static let logType = "SocketPacket"
+
     let nsp: String
     let id: Int
     let type: PacketType
@@ -113,7 +115,7 @@ struct SocketPacket {
                     
                     message += jsonString! as String + ","
                 } catch {
-                    print("Error creating JSON object in SocketPacket.completeMessage")
+					Logger.error("Error creating JSON object in SocketPacket.completeMessage", type: SocketPacket.logType)
                 }
             } else if var str = arg as? String {
                 str = str["\n"] ~= "\\\\n"

--- a/SocketIOClientSwift/SwiftRegex.swift
+++ b/SocketIOClientSwift/SwiftRegex.swift
@@ -36,12 +36,11 @@ public class SwiftRegex: NSObject, BooleanType {
         }
         super.init()
     }
-    
-    static func failure(message: String) {
-        print("SwiftRegex: "+message)
-        //assert(false,"SwiftRegex: failed")
-    }
-    
+	
+	private static func failure(message: String) {
+		fatalError("SwiftRegex: \(message)")
+	}
+
     final var targetRange: NSRange {
         return NSRange(location: 0,length: target.utf16.count)
     }

--- a/SocketIOClientSwift/SwiftRegex.swift
+++ b/SocketIOClientSwift/SwiftRegex.swift
@@ -13,9 +13,9 @@
 
 import Foundation
 
-var swiftRegexCache = [String: NSRegularExpression]()
+private var swiftRegexCache = [String: NSRegularExpression]()
 
-public class SwiftRegex: NSObject, BooleanType {
+internal class SwiftRegex: NSObject, BooleanType {
     var target:String
     var regex: NSRegularExpression
     
@@ -36,16 +36,16 @@ public class SwiftRegex: NSObject, BooleanType {
         }
         super.init()
     }
-	
+
 	private static func failure(message: String) {
 		fatalError("SwiftRegex: \(message)")
 	}
 
-    final var targetRange: NSRange {
+    private final var targetRange: NSRange {
         return NSRange(location: 0,length: target.utf16.count)
     }
     
-    final func substring(range: NSRange) -> String? {
+    private final func substring(range: NSRange) -> String? {
         if ( range.location != NSNotFound ) {
             return (target as NSString).substringWithRange(range)
         } else {
@@ -53,24 +53,24 @@ public class SwiftRegex: NSObject, BooleanType {
         }
     }
     
-    public func doesMatch(options: NSMatchingOptions!) -> Bool {
+    func doesMatch(options: NSMatchingOptions!) -> Bool {
         return range(options).location != NSNotFound
     }
     
-    public func range(options: NSMatchingOptions) -> NSRange {
+    func range(options: NSMatchingOptions) -> NSRange {
         return regex.rangeOfFirstMatchInString(target as String, options: [], range: targetRange)
     }
     
-    public func match(options: NSMatchingOptions) -> String? {
+    func match(options: NSMatchingOptions) -> String? {
         return substring(range(options))
     }
     
-    public func groups() -> [String]? {
+    func groups() -> [String]? {
         return groupsForMatch(regex.firstMatchInString(target as String, options:
             NSMatchingOptions.WithoutAnchoringBounds, range: targetRange))
     }
     
-    func groupsForMatch(match: NSTextCheckingResult!) -> [String]? {
+    private func groupsForMatch(match: NSTextCheckingResult!) -> [String]? {
         if match != nil {
             var groups = [String]()
             for groupno in 0...regex.numberOfCaptureGroups {
@@ -86,7 +86,7 @@ public class SwiftRegex: NSObject, BooleanType {
         }
     }
     
-    public subscript(groupno: Int) -> String? {
+    subscript(groupno: Int) -> String? {
         get {
             return groups()?[groupno]
         }
@@ -115,19 +115,19 @@ public class SwiftRegex: NSObject, BooleanType {
         return matches
     }
     
-    public func ranges() -> [NSRange] {
+    func ranges() -> [NSRange] {
         return matchResults().map { $0.range }
     }
     
-    public func matches() -> [String] {
+    func matches() -> [String] {
         return matchResults().map( { self.substring($0.range)!})
     }
     
-    public func allGroups() -> [[String]?] {
+    func allGroups() -> [[String]?] {
         return matchResults().map {self.groupsForMatch($0)}
     }
     
-    public func dictionary(options: NSMatchingOptions!) -> Dictionary<String,String> {
+    func dictionary(options: NSMatchingOptions!) -> Dictionary<String,String> {
         var out = Dictionary<String,String>()
         for match in matchResults() {
             out[substring(match.rangeAtIndex(1))!] = substring(match.rangeAtIndex(2))!
@@ -152,31 +152,31 @@ public class SwiftRegex: NSObject, BooleanType {
             return out as String
     }
     
-    public var boolValue: Bool {
+    var boolValue: Bool {
         return doesMatch(nil)
     }
 }
 
 extension String {
-    public subscript(pattern: String, options: NSRegularExpressionOptions) -> SwiftRegex {
+    subscript(pattern: String, options: NSRegularExpressionOptions) -> SwiftRegex {
         return SwiftRegex(target: self, pattern: pattern, options: options)
     }
 }
 
 extension String {
-    public subscript(pattern: String) -> SwiftRegex {
+    subscript(pattern: String) -> SwiftRegex {
         return SwiftRegex(target: self, pattern: pattern, options: nil)
     }
 }
 
-public func ~= (left: SwiftRegex, right: String) -> String {
+func ~= (left: SwiftRegex, right: String) -> String {
     return left.substituteMatches({match, stop in
         return left.regex.replacementStringForResult( match,
             inString: left.target as String, offset: 0, template: right )
         }, options: [])
 }
 
-public func ~= (left: SwiftRegex, right: [String]) -> String {
+func ~= (left: SwiftRegex, right: [String]) -> String {
     var matchNumber = 0
     return left.substituteMatches({match, stop -> String in
         
@@ -189,7 +189,7 @@ public func ~= (left: SwiftRegex, right: [String]) -> String {
         }, options: [])
 }
 
-public func ~= (left: SwiftRegex, right: (String) -> String) -> String {
+func ~= (left: SwiftRegex, right: (String) -> String) -> String {
     // return right(left.substring(match.range))
     return left.substituteMatches(
         {match, stop -> String in
@@ -197,7 +197,7 @@ public func ~= (left: SwiftRegex, right: (String) -> String) -> String {
         }, options: [])
 }
 
-public func ~= (left: SwiftRegex, right: ([String]?) -> String) -> String {
+func ~= (left: SwiftRegex, right: ([String]?) -> String) -> String {
     return left.substituteMatches({match, stop -> String in
         return right(left.groupsForMatch(match))
         }, options: [])

--- a/SocketIOClientSwift/SwiftRegex.swift
+++ b/SocketIOClientSwift/SwiftRegex.swift
@@ -37,7 +37,7 @@ public class SwiftRegex: NSObject, BooleanType {
         super.init()
     }
     
-    class func failure(message: String) {
+    static func failure(message: String) {
         print("SwiftRegex: "+message)
         //assert(false,"SwiftRegex: failed")
     }

--- a/SocketIOClientSwift/SwiftRegex.swift
+++ b/SocketIOClientSwift/SwiftRegex.swift
@@ -37,9 +37,9 @@ internal class SwiftRegex: NSObject, BooleanType {
         super.init()
     }
 
-	private static func failure(message: String) {
-		fatalError("SwiftRegex: \(message)")
-	}
+    private static func failure(message: String) {
+        fatalError("SwiftRegex: \(message)")
+    }
 
     private final var targetRange: NSRange {
         return NSRange(location: 0,length: target.utf16.count)

--- a/SocketIOClientSwift/WebSocket.swift
+++ b/SocketIOClientSwift/WebSocket.swift
@@ -378,7 +378,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
         }
         if totalSize > 0 {
             if validateResponse(buffer, bufferLen: totalSize) {
-				dispatch_async(queue, {
+                dispatch_async(queue, {
                     self.connected = true
                     if let connectBlock = self.onConnect {
                         connectBlock()
@@ -522,7 +522,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
             }
             if receivedOpcode == OpCode.Pong.rawValue {
                 dispatch_async(queue, {
-					self.onPong?()
+                    self.onPong?()
                     self.pongDelegate?.websocketDidReceivePong(self)
                 })
                 
@@ -609,20 +609,20 @@ public class WebSocket : NSObject, NSStreamDelegate {
             } else if response.code == .TextFrame {
                 let str: NSString? = NSString(data: response.buffer!, encoding: NSUTF8StringEncoding)
 
-				if let str = str as String? {
-					dispatch_async(queue, {
-						self.onText?(str)
-						self.delegate?.websocketDidReceiveMessage(self, text: str)
-					})
-				} else {
-					writeError(CloseCode.Encoding.rawValue)
-					return false
-				}
+                if let str = str as String? {
+                    dispatch_async(queue, {
+                        self.onText?(str)
+                        self.delegate?.websocketDidReceiveMessage(self, text: str)
+                    })
+                } else {
+                    writeError(CloseCode.Encoding.rawValue)
+                    return false
+                }
             } else if response.code == .BinaryFrame {
                 let data = response.buffer! //local copy so it is perverse for writing
-				dispatch_async(queue) {
-					self.onData?(data)
-					self.delegate?.websocketDidReceiveData(self, data: data)
+                dispatch_async(queue) {
+                    self.onData?(data)
+                    self.delegate?.websocketDidReceiveData(self, data: data)
                 }
             }
 
@@ -726,11 +726,11 @@ public class WebSocket : NSObject, NSStreamDelegate {
     ///used to preform the disconnect delegate
     private func doDisconnect(error: NSError?) {
         if !self.didDisconnect {
-			dispatch_async(queue) {
+            dispatch_async(queue) {
                 self.didDisconnect = true
 
-				self.onDisconnect?(error)
-				self.delegate?.websocketDidDisconnect(self, error: error)
+                self.onDisconnect?(error)
+                self.delegate?.websocketDidDisconnect(self, error: error)
             }
         }
     }

--- a/SocketIOClientSwift/WebSocket.swift
+++ b/SocketIOClientSwift/WebSocket.swift
@@ -750,7 +750,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
 import Foundation
 import Security
 
-public class SSLCert {
+private class SSLCert {
     var certData: NSData?
     var key: SecKeyRef?
     
@@ -761,7 +761,7 @@ public class SSLCert {
     
     :returns: a representation security object to be used with
     */
-    public init(data: NSData) {
+    init(data: NSData) {
         self.certData = data
     }
     
@@ -772,7 +772,7 @@ public class SSLCert {
     
     :returns: a representation security object to be used with
     */
-    public init(key: SecKeyRef) {
+    init(key: SecKeyRef) {
         self.key = key
     }
 }


### PR DESCRIPTION
I made a bunch of comments in #96, and here's my proposed solution to them, plus a few other improvements I've found along the way. Let me know what you think.
All tests are still passing.

### Changes:
- `SSLCert` is now `private`.
- `WebSockets`: removed unnecessary `weak`s and simplified code.
- `SwiftRegex` does not need to be exposed.
- `SwiftRegex`: failing with `fatalError`.
- `SwiftRegex`: changed static method to `static` to avoid unnecessary dynamic dispatching.
- `SocketPacket`: using `Logger` instead of `print`.
- `SocketIOClient`: simplified conditional.
- `SocketIOClient`: remove unnecessary `optional`.
- `SocketIOClient`: removed unnecessary `weak self`.
- `SocketIOClient`: added assertion to check `timeoutAfter` is not negative.
- `SocketIOClient`: making a few fields `private`.
- Simplified `SocketEngine.swift`.