### PR TITLE
Added support for tvOS

### DIFF
--- a/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
+++ b/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
@@ -12,6 +12,47 @@
 		572EF23D1B51F18A00EEBB58 /* SocketIO-Mac.h in Headers */ = {isa = PBXBuildFile; fileRef = 572EF23C1B51F18A00EEBB58 /* SocketIO-Mac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		572EF2431B51F18A00EEBB58 /* SocketIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 572EF2381B51F18A00EEBB58 /* SocketIO.framework */; };
 		572EF24A1B51F18A00EEBB58 /* SocketIO_MacTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572EF2491B51F18A00EEBB58 /* SocketIO_MacTests.swift */; };
+		57425F9C1BA3A46000BDAAC1 /* SocketGenericParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D765611B9F0D870028551C /* SocketGenericParser.swift */; };
+		57425F9D1BA3A46000BDAAC1 /* SocketEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7E1B51F254004FF46E /* SocketEngine.swift */; };
+		57425F9E1BA3A46000BDAAC1 /* SocketParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF851B51F254004FF46E /* SocketParser.swift */; };
+		57425F9F1BA3A46000BDAAC1 /* SocketTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF861B51F254004FF46E /* SocketTypes.swift */; };
+		57425FA01BA3A46000BDAAC1 /* SocketEngineClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7F1B51F254004FF46E /* SocketEngineClient.swift */; };
+		57425FA11BA3A46000BDAAC1 /* SocketEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF801B51F254004FF46E /* SocketEventHandler.swift */; };
+		57425FA21BA3A46000BDAAC1 /* SocketFixUTF8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF811B51F254004FF46E /* SocketFixUTF8.swift */; };
+		57425FA31BA3A46000BDAAC1 /* SocketIOClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF821B51F254004FF46E /* SocketIOClient.swift */; };
+		57425FA41BA3A46000BDAAC1 /* SocketAnyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7D1B51F254004FF46E /* SocketAnyEvent.swift */; };
+		57425FA51BA3A46000BDAAC1 /* SocketLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF831B51F254004FF46E /* SocketLogger.swift */; };
+		57425FA61BA3A46000BDAAC1 /* SocketIOClientStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74781D591B7E83930042CACA /* SocketIOClientStatus.swift */; };
+		57425FA71BA3A46000BDAAC1 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF881B51F254004FF46E /* WebSocket.swift */; };
+		57425FA81BA3A46000BDAAC1 /* SocketPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF841B51F254004FF46E /* SocketPacket.swift */; };
+		57425FA91BA3A46000BDAAC1 /* SocketAckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7C1B51F254004FF46E /* SocketAckManager.swift */; };
+		57425FAA1BA3A46000BDAAC1 /* SwiftRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF871B51F254004FF46E /* SwiftRegex.swift */; };
+		57425FAD1BA3A46000BDAAC1 /* SocketIO-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 572EF21E1B51F16C00EEBB58 /* SocketIO-iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		57425FDC1BA3A4F100BDAAC1 /* SocketGenericParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D765611B9F0D870028551C /* SocketGenericParser.swift */; };
+		57425FDD1BA3A4F100BDAAC1 /* SocketParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF851B51F254004FF46E /* SocketParser.swift */; };
+		57425FDE1BA3A4F100BDAAC1 /* SocketPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF841B51F254004FF46E /* SocketPacket.swift */; };
+		57425FDF1BA3A4F100BDAAC1 /* SocketFixUTF8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF811B51F254004FF46E /* SocketFixUTF8.swift */; };
+		57425FE01BA3A4F100BDAAC1 /* SocketEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF801B51F254004FF46E /* SocketEventHandler.swift */; };
+		57425FE11BA3A4F100BDAAC1 /* SocketTestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CB8F0A1B6E48B90019ED53 /* SocketTestCases.swift */; };
+		57425FE21BA3A4F100BDAAC1 /* SocketEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7E1B51F254004FF46E /* SocketEngine.swift */; };
+		57425FE31BA3A4F100BDAAC1 /* SocketAckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7C1B51F254004FF46E /* SocketAckManager.swift */; };
+		57425FE41BA3A4F100BDAAC1 /* TestKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941A4AB91B67A56C00C42318 /* TestKind.swift */; };
+		57425FE51BA3A4F100BDAAC1 /* AbstractSocketTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CB8F0C1B6E66E60019ED53 /* AbstractSocketTest.swift */; };
+		57425FE61BA3A4F100BDAAC1 /* SocketEmitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945B65421B63D9DB0081E995 /* SocketEmitTest.swift */; };
+		57425FE71BA3A4F100BDAAC1 /* SwiftRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF871B51F254004FF46E /* SwiftRegex.swift */; };
+		57425FE81BA3A4F100BDAAC1 /* SocketLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF831B51F254004FF46E /* SocketLogger.swift */; };
+		57425FE91BA3A4F100BDAAC1 /* SocketAckManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A20D601B99E22F00BF9E44 /* SocketAckManagerTest.swift */; };
+		57425FEA1BA3A4F100BDAAC1 /* SocketEngineClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7F1B51F254004FF46E /* SocketEngineClient.swift */; };
+		57425FEB1BA3A4F100BDAAC1 /* SocketAnyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7D1B51F254004FF46E /* SocketAnyEvent.swift */; };
+		57425FEC1BA3A4F100BDAAC1 /* SocketAcknowledgementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94ADAC4A1B6632DD00FD79AE /* SocketAcknowledgementTest.swift */; };
+		57425FED1BA3A4F100BDAAC1 /* SocketTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF861B51F254004FF46E /* SocketTypes.swift */; };
+		57425FEE1BA3A4F100BDAAC1 /* SocketIOClientStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74781D591B7E83930042CACA /* SocketIOClientStatus.swift */; };
+		57425FEF1BA3A4F100BDAAC1 /* SocketIOClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF821B51F254004FF46E /* SocketIOClient.swift */; };
+		57425FF01BA3A4F100BDAAC1 /* SocketParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949FAE8C1B9B94E600073BE9 /* SocketParserTest.swift */; };
+		57425FF11BA3A4F100BDAAC1 /* SocketNamespaceEmitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94ADAC481B652D3300FD79AE /* SocketNamespaceEmitTest.swift */; };
+		57425FF21BA3A4F100BDAAC1 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF881B51F254004FF46E /* WebSocket.swift */; };
+		57425FF31BA3A4F100BDAAC1 /* SocketNamespaceAcknowledgementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94242BB71B67B0E500AAAC9D /* SocketNamespaceAcknowledgementTest.swift */; };
+		57425FF51BA3A4F100BDAAC1 /* SocketIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 572EF2191B51F16C00EEBB58 /* SocketIO.framework */; };
 		5764DF891B51F254004FF46E /* SocketAckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7C1B51F254004FF46E /* SocketAckManager.swift */; };
 		5764DF8A1B51F254004FF46E /* SocketAckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7C1B51F254004FF46E /* SocketAckManager.swift */; };
 		5764DF8B1B51F254004FF46E /* SocketAnyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF7D1B51F254004FF46E /* SocketAnyEvent.swift */; };
@@ -61,8 +102,8 @@
 		945B65401B5FCEEA0081E995 /* SwiftRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF871B51F254004FF46E /* SwiftRegex.swift */; };
 		945B65411B5FCEEA0081E995 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5764DF881B51F254004FF46E /* WebSocket.swift */; };
 		945B65431B63D9DB0081E995 /* SocketEmitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945B65421B63D9DB0081E995 /* SocketEmitTest.swift */; };
-		949FAE8D1B9B94E600073BE9 /* SocketParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949FAE8C1B9B94E600073BE9 /* SocketParserTest.swift */; settings = {ASSET_TAGS = (); }; };
-		94A20D611B99E22F00BF9E44 /* SocketAckManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A20D601B99E22F00BF9E44 /* SocketAckManagerTest.swift */; settings = {ASSET_TAGS = (); }; };
+		949FAE8D1B9B94E600073BE9 /* SocketParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949FAE8C1B9B94E600073BE9 /* SocketParserTest.swift */; };
+		94A20D611B99E22F00BF9E44 /* SocketAckManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A20D601B99E22F00BF9E44 /* SocketAckManagerTest.swift */; };
 		94ADAC491B652D3300FD79AE /* SocketNamespaceEmitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94ADAC481B652D3300FD79AE /* SocketNamespaceEmitTest.swift */; };
 		94ADAC4B1B6632DD00FD79AE /* SocketAcknowledgementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94ADAC4A1B6632DD00FD79AE /* SocketAcknowledgementTest.swift */; };
 		94CB8F0B1B6E48B90019ED53 /* SocketTestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CB8F0A1B6E48B90019ED53 /* SocketTestCases.swift */; };
@@ -84,6 +125,13 @@
 			remoteGlobalIDString = 572EF2371B51F18A00EEBB58;
 			remoteInfo = "SocketIO-Mac";
 		};
+		57425FDA1BA3A4F100BDAAC1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 572EF20E1B51F12F00EEBB58 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 572EF2181B51F16C00EEBB58;
+			remoteInfo = "SocketIO-iOS";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -98,6 +146,8 @@
 		572EF2421B51F18A00EEBB58 /* SocketIO-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SocketIO-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		572EF2481B51F18A00EEBB58 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		572EF2491B51F18A00EEBB58 /* SocketIO_MacTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketIO_MacTests.swift; sourceTree = "<group>"; };
+		57425FB21BA3A46000BDAAC1 /* SocketIO.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SocketIO.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		57425FFA1BA3A4F100BDAAC1 /* SocketIO-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SocketIO-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5764DF7C1B51F254004FF46E /* SocketAckManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SocketAckManager.swift; path = SocketIOClientSwift/SocketAckManager.swift; sourceTree = "<group>"; };
 		5764DF7D1B51F254004FF46E /* SocketAnyEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SocketAnyEvent.swift; path = SocketIOClientSwift/SocketAnyEvent.swift; sourceTree = "<group>"; };
 		5764DF7E1B51F254004FF46E /* SocketEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SocketEngine.swift; path = SocketIOClientSwift/SocketEngine.swift; sourceTree = "<group>"; };
@@ -155,6 +205,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57425FAB1BA3A46000BDAAC1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57425FF41BA3A4F100BDAAC1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57425FF51BA3A4F100BDAAC1 /* SocketIO.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -177,6 +242,8 @@
 				572EF2241B51F16C00EEBB58 /* SocketIO-iOSTests.xctest */,
 				572EF2381B51F18A00EEBB58 /* SocketIO.framework */,
 				572EF2421B51F18A00EEBB58 /* SocketIO-MacTests.xctest */,
+				57425FB21BA3A46000BDAAC1 /* SocketIO.framework */,
+				57425FFA1BA3A4F100BDAAC1 /* SocketIO-tvOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -298,6 +365,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57425FAC1BA3A46000BDAAC1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57425FAD1BA3A46000BDAAC1 /* SocketIO-iOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -373,6 +448,42 @@
 			productReference = 572EF2421B51F18A00EEBB58 /* SocketIO-MacTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		57425F9A1BA3A46000BDAAC1 /* SocketIO-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57425FAF1BA3A46000BDAAC1 /* Build configuration list for PBXNativeTarget "SocketIO-tvOS" */;
+			buildPhases = (
+				57425F9B1BA3A46000BDAAC1 /* Sources */,
+				57425FAB1BA3A46000BDAAC1 /* Frameworks */,
+				57425FAC1BA3A46000BDAAC1 /* Headers */,
+				57425FAE1BA3A46000BDAAC1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SocketIO-tvOS";
+			productName = "SocketIO-iOS";
+			productReference = 57425FB21BA3A46000BDAAC1 /* SocketIO.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		57425FD81BA3A4F100BDAAC1 /* SocketIO-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57425FF71BA3A4F100BDAAC1 /* Build configuration list for PBXNativeTarget "SocketIO-tvOSTests" */;
+			buildPhases = (
+				57425FDB1BA3A4F100BDAAC1 /* Sources */,
+				57425FF41BA3A4F100BDAAC1 /* Frameworks */,
+				57425FF61BA3A4F100BDAAC1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				57425FD91BA3A4F100BDAAC1 /* PBXTargetDependency */,
+			);
+			name = "SocketIO-tvOSTests";
+			productName = "SocketIO-iOSTests";
+			productReference = 57425FFA1BA3A4F100BDAAC1 /* SocketIO-tvOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -410,6 +521,8 @@
 			targets = (
 				572EF2181B51F16C00EEBB58 /* SocketIO-iOS */,
 				572EF2231B51F16C00EEBB58 /* SocketIO-iOSTests */,
+				57425F9A1BA3A46000BDAAC1 /* SocketIO-tvOS */,
+				57425FD81BA3A4F100BDAAC1 /* SocketIO-tvOSTests */,
 				572EF2371B51F18A00EEBB58 /* SocketIO-Mac */,
 				572EF2411B51F18A00EEBB58 /* SocketIO-MacTests */,
 			);
@@ -439,6 +552,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		572EF2401B51F18A00EEBB58 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57425FAE1BA3A46000BDAAC1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57425FF61BA3A4F100BDAAC1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -532,6 +659,59 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57425F9B1BA3A46000BDAAC1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57425F9C1BA3A46000BDAAC1 /* SocketGenericParser.swift in Sources */,
+				57425F9D1BA3A46000BDAAC1 /* SocketEngine.swift in Sources */,
+				57425F9E1BA3A46000BDAAC1 /* SocketParser.swift in Sources */,
+				57425F9F1BA3A46000BDAAC1 /* SocketTypes.swift in Sources */,
+				57425FA01BA3A46000BDAAC1 /* SocketEngineClient.swift in Sources */,
+				57425FA11BA3A46000BDAAC1 /* SocketEventHandler.swift in Sources */,
+				57425FA21BA3A46000BDAAC1 /* SocketFixUTF8.swift in Sources */,
+				57425FA31BA3A46000BDAAC1 /* SocketIOClient.swift in Sources */,
+				57425FA41BA3A46000BDAAC1 /* SocketAnyEvent.swift in Sources */,
+				57425FA51BA3A46000BDAAC1 /* SocketLogger.swift in Sources */,
+				57425FA61BA3A46000BDAAC1 /* SocketIOClientStatus.swift in Sources */,
+				57425FA71BA3A46000BDAAC1 /* WebSocket.swift in Sources */,
+				57425FA81BA3A46000BDAAC1 /* SocketPacket.swift in Sources */,
+				57425FA91BA3A46000BDAAC1 /* SocketAckManager.swift in Sources */,
+				57425FAA1BA3A46000BDAAC1 /* SwiftRegex.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57425FDB1BA3A4F100BDAAC1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57425FDC1BA3A4F100BDAAC1 /* SocketGenericParser.swift in Sources */,
+				57425FDD1BA3A4F100BDAAC1 /* SocketParser.swift in Sources */,
+				57425FDE1BA3A4F100BDAAC1 /* SocketPacket.swift in Sources */,
+				57425FDF1BA3A4F100BDAAC1 /* SocketFixUTF8.swift in Sources */,
+				57425FE01BA3A4F100BDAAC1 /* SocketEventHandler.swift in Sources */,
+				57425FE11BA3A4F100BDAAC1 /* SocketTestCases.swift in Sources */,
+				57425FE21BA3A4F100BDAAC1 /* SocketEngine.swift in Sources */,
+				57425FE31BA3A4F100BDAAC1 /* SocketAckManager.swift in Sources */,
+				57425FE41BA3A4F100BDAAC1 /* TestKind.swift in Sources */,
+				57425FE51BA3A4F100BDAAC1 /* AbstractSocketTest.swift in Sources */,
+				57425FE61BA3A4F100BDAAC1 /* SocketEmitTest.swift in Sources */,
+				57425FE71BA3A4F100BDAAC1 /* SwiftRegex.swift in Sources */,
+				57425FE81BA3A4F100BDAAC1 /* SocketLogger.swift in Sources */,
+				57425FE91BA3A4F100BDAAC1 /* SocketAckManagerTest.swift in Sources */,
+				57425FEA1BA3A4F100BDAAC1 /* SocketEngineClient.swift in Sources */,
+				57425FEB1BA3A4F100BDAAC1 /* SocketAnyEvent.swift in Sources */,
+				57425FEC1BA3A4F100BDAAC1 /* SocketAcknowledgementTest.swift in Sources */,
+				57425FED1BA3A4F100BDAAC1 /* SocketTypes.swift in Sources */,
+				57425FEE1BA3A4F100BDAAC1 /* SocketIOClientStatus.swift in Sources */,
+				57425FEF1BA3A4F100BDAAC1 /* SocketIOClient.swift in Sources */,
+				57425FF01BA3A4F100BDAAC1 /* SocketParserTest.swift in Sources */,
+				57425FF11BA3A4F100BDAAC1 /* SocketNamespaceEmitTest.swift in Sources */,
+				57425FF21BA3A4F100BDAAC1 /* WebSocket.swift in Sources */,
+				57425FF31BA3A4F100BDAAC1 /* SocketNamespaceAcknowledgementTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -544,6 +724,11 @@
 			isa = PBXTargetDependency;
 			target = 572EF2371B51F18A00EEBB58 /* SocketIO-Mac */;
 			targetProxy = 572EF2441B51F18A00EEBB58 /* PBXContainerItemProxy */;
+		};
+		57425FD91BA3A4F100BDAAC1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 572EF2181B51F16C00EEBB58 /* SocketIO-iOS */;
+			targetProxy = 57425FDA1BA3A4F100BDAAC1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -959,6 +1144,203 @@
 			};
 			name = Release;
 		};
+		57425FB01BA3A46000BDAAC1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SocketIO-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		57425FB11BA3A46000BDAAC1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SocketIO-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		57425FF81BA3A4F100BDAAC1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SocketIO-iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		57425FF91BA3A4F100BDAAC1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SocketIO-iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1003,6 +1385,24 @@
 			buildConfigurations = (
 				572EF24F1B51F18A00EEBB58 /* Debug */,
 				572EF2501B51F18A00EEBB58 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57425FAF1BA3A46000BDAAC1 /* Build configuration list for PBXNativeTarget "SocketIO-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57425FB01BA3A46000BDAAC1 /* Debug */,
+				57425FB11BA3A46000BDAAC1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57425FF71BA3A4F100BDAAC1 /* Build configuration list for PBXNativeTarget "SocketIO-tvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57425FF81BA3A4F100BDAAC1 /* Debug */,
+				57425FF91BA3A4F100BDAAC1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Socket.IO-Client-Swift.xcodeproj/xcshareddata/xcschemes/SocketIO-tvOS.xcscheme
+++ b/Socket.IO-Client-Swift.xcodeproj/xcshareddata/xcschemes/SocketIO-tvOS.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "57425F9A1BA3A46000BDAAC1"
+               BuildableName = "SocketIO.framework"
+               BlueprintName = "SocketIO-tvOS"
+               ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "57425FD81BA3A4F100BDAAC1"
+               BuildableName = "SocketIO-tvOSTests.xctest"
+               BlueprintName = "SocketIO-tvOSTests"
+               ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "57425FD81BA3A4F100BDAAC1"
+               BuildableName = "SocketIO-tvOSTests.xctest"
+               BlueprintName = "SocketIO-tvOSTests"
+               ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "57425F9A1BA3A46000BDAAC1"
+            BuildableName = "SocketIO.framework"
+            BlueprintName = "SocketIO-tvOS"
+            ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "57425F9A1BA3A46000BDAAC1"
+            BuildableName = "SocketIO.framework"
+            BlueprintName = "SocketIO-tvOS"
+            ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "57425F9A1BA3A46000BDAAC1"
+            BuildableName = "SocketIO.framework"
+            BlueprintName = "SocketIO-tvOS"
+            ReferencedContainer = "container:Socket.IO-Client-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Changes:

- Duplicated target for both framework and tests.
- Set the right platform on new targets.
- Changed `tvOS` framework target product name to `SocketIO`.
- Changed targets `plist`s to use the existing ones, and removed the copies.
- Configured scheme to use the right test target.
- Shared scheme.
- Verified `tvOS` tests pass.

![screen shot 2015-09-11 at 17 15 58](https://cloud.githubusercontent.com/assets/685609/9828854/c98e6c94-58a8-11e5-972d-7f9160a8e910.png)
