### PR TITLE
Enabled Bitcode

### DIFF
--- a/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
+++ b/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
@@ -561,7 +561,9 @@
 		572EF2121B51F12F00EEBB58 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				ENABLE_BITCODE = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				PRODUCT_NAME = SocketIO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -571,7 +573,9 @@
 		572EF2131B51F12F00EEBB58 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				ENABLE_BITCODE = YES;
 				PRODUCT_NAME = SocketIO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};


### PR DESCRIPTION
Setting `BITCODE_GENERATION_MODE` is necessary to ensure that `Carthage` builds frameworks with `bitcode`. See [this issue](https://github.com/Carthage/Carthage/issues/535) for details.