### PR TITLE
Add CocoaSeeds installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,13 @@ $ pod install
 Import the module:
 
 Swift:
-```
-swift
+```swift
 import Socket_IO_Client_Swift
 ```
 
 Objective-C:
 
-```
-Objective-C
+```Objective-C
 #import <Socket_IO_Client_Swift/Socket_IO_Client_Swift-Swift.h>
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,14 +95,29 @@ $ pod install
 Import the module:
 
 Swift:
-```swift
+```
+swift
 import Socket_IO_Client_Swift
 ```
 
 Objective-C:
-```Objective-C
+
+```
+Objective-C
 #import <Socket_IO_Client_Swift/Socket_IO_Client_Swift-Swift.h>
 ```
+
+CocoaSeeds
+-----------------
+
+Add this line to your `Seedfile`:
+
+```
+github "socketio/socket.io-client-swift", "v3.1.4", :files => "SocketIOClientSwift/*.swift" # Or latest version
+```
+
+Run `seed install`.
+
 
 ##API
 Constructors


### PR DESCRIPTION
[CocoaSeeds](https://github.com/devxoul/CocoaSeeds) is another way to add a third party in a project without installing it manually. It's useful for the CocoaPods's users who can't add swift pods, or who are supporting iOS7.

I discover it today, and it's really useful in my case to avoid to add Socket.io manually :)