### PR TITLE
fix timeoutAfter handler always close connection

### DIFF
--- a/Source/SocketIOClient.swift
+++ b/Source/SocketIOClient.swift
@@ -169,7 +169,7 @@ public final class SocketIOClient: NSObject, SocketEngineClient, SocketParsable 
         let time = dispatch_time(DISPATCH_TIME_NOW, Int64(timeoutAfter) * Int64(NSEC_PER_SEC))
 
         dispatch_after(time, handleQueue) {[weak self] in
-            if let this = self where this.status != .Connected || this.status != .Closed {
+            if let this = self where this.status != .Connected && this.status != .Closed {
                 this.status = .Closed
                 this.engine?.disconnect("Connect timeout")
 


### PR DESCRIPTION
Currently the status check always results in true therefore the socket is closed every-time a timeout is evaluated