### PR TITLE
Websocket compression [DONT MERGE]

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -15,7 +15,8 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
   s.source       = { :git => "https://github.com/socketio/socket.io-client-swift.git", :tag => 'v6.0.0' }
-  s.source_files  = "Source/**/*.swift"
+  s.source_files  = "Source/*"
   s.requires_arc = true
   # s.dependency 'Starscream', '~> 0.9' # currently this repo includes Starscream swift files
+  s.library = 'z'
 end

--- a/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
+++ b/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3064D9B71CB8308000F0B34E /* Socket.IO-Client-Swift-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 3064D9B31CB8308000F0B34E /* Socket.IO-Client-Swift-Bridging-Header.h */; };
+		3064D9C41CBAB42600F0B34E /* DeflateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3064D9C21CBAB42600F0B34E /* DeflateHelper.h */; };
+		3064D9C51CBAB42600F0B34E /* DeflateHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3064D9C31CBAB42600F0B34E /* DeflateHelper.m */; };
 		572EF21F1B51F16C00EEBB58 /* SocketIO-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 572EF21E1B51F16C00EEBB58 /* SocketIO-iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		572EF2251B51F16C00EEBB58 /* SocketIOClientSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 572EF2191B51F16C00EEBB58 /* SocketIOClientSwift.framework */; };
 		572EF23D1B51F18A00EEBB58 /* SocketIO-Mac.h in Headers */ = {isa = PBXBuildFile; fileRef = 572EF23C1B51F18A00EEBB58 /* SocketIO-Mac.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -154,6 +157,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3064D9B31CB8308000F0B34E /* Socket.IO-Client-Swift-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Socket.IO-Client-Swift-Bridging-Header.h"; path = "Source/Socket.IO-Client-Swift-Bridging-Header.h"; sourceTree = "<group>"; };
+		3064D9C21CBAB42600F0B34E /* DeflateHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeflateHelper.h; path = Source/DeflateHelper.h; sourceTree = "<group>"; };
+		3064D9C31CBAB42600F0B34E /* DeflateHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DeflateHelper.m; path = Source/DeflateHelper.m; sourceTree = "<group>"; };
 		572EF2191B51F16C00EEBB58 /* SocketIOClientSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SocketIOClientSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		572EF21D1B51F16C00EEBB58 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		572EF21E1B51F16C00EEBB58 /* SocketIO-iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SocketIO-iOS.h"; sourceTree = "<group>"; };
@@ -344,6 +350,7 @@
 		5764DF7B1B51F24A004FF46E /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				3064D9B31CB8308000F0B34E /* Socket.IO-Client-Swift-Bridging-Header.h */,
 				74171E501C10CD240062D398 /* SocketAckEmitter.swift */,
 				74171E511C10CD240062D398 /* SocketAckManager.swift */,
 				74171E521C10CD240062D398 /* SocketAnyEvent.swift */,
@@ -365,6 +372,8 @@
 				74171E601C10CD240062D398 /* SocketTypes.swift */,
 				74171E611C10CD240062D398 /* SwiftRegex.swift */,
 				74171E621C10CD240062D398 /* WebSocket.swift */,
+				3064D9C21CBAB42600F0B34E /* DeflateHelper.h */,
+				3064D9C31CBAB42600F0B34E /* DeflateHelper.m */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -376,7 +385,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3064D9B71CB8308000F0B34E /* Socket.IO-Client-Swift-Bridging-Header.h in Headers */,
 				572EF21F1B51F16C00EEBB58 /* SocketIO-iOS.h in Headers */,
+				3064D9C41CBAB42600F0B34E /* DeflateHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -607,6 +618,7 @@
 				74171E751C10CD240062D398 /* SocketEngine.swift in Sources */,
 				74171E691C10CD240062D398 /* SocketAckManager.swift in Sources */,
 				7420CB791C49629E00956AA4 /* SocketEnginePollable.swift in Sources */,
+				3064D9C51CBAB42600F0B34E /* DeflateHelper.m in Sources */,
 				74ABF7771C3991C10078C657 /* SocketClientSpec.swift in Sources */,
 				74171E871C10CD240062D398 /* SocketEngineSpec.swift in Sources */,
 				74171E631C10CD240062D398 /* SocketAckEmitter.swift in Sources */,
@@ -857,6 +869,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.socket.SocketIOClientSwift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Socket.IO-Client-Swift-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -907,6 +920,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.socket.SocketIOClientSwift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Socket.IO-Client-Swift-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Source/DeflateHelper.h
+++ b/Source/DeflateHelper.h
@@ -1,0 +1,16 @@
+//
+//  DeflateHelper.h
+//  Socket.IO-Client-Swift
+//
+//  Created by Danny Ricciotti on 4/10/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface DeflateHelper : NSObject
+
+
+- (NSData *)inflate:(NSData *)data;
+
+@end

--- a/Source/DeflateHelper.m
+++ b/Source/DeflateHelper.m
@@ -1,0 +1,64 @@
+//
+//  DeflateHelper.m
+//  Socket.IO-Client-Swift
+//
+//  Created by Danny Ricciotti on 4/10/16.
+//
+//
+
+#import "DeflateHelper.h"
+#import <zlib.h>
+
+@interface DeflateHelper()
+//@property z_stream inflator;
+@end
+
+
+@implementation DeflateHelper
+
+/**
+ * Inflates a websocket payload.
+ * The default values in socket.io are {"flush":2,"windowBits":15,"memLevel":8}
+ */
+- (NSData *)inflate:(NSData *)data {
+    
+    z_stream _inflator = {0};
+    inflateInit2(&_inflator, -15);
+    
+    NSMutableData *output = [NSMutableData data];
+    
+    NSInteger inputLength = data.length;
+    
+    size_t consumedInput = 0;
+    while (consumedInput < inputLength ) {
+        NSUInteger outputPosition = output.length;
+        [output setLength:outputPosition + 4096];
+        NSUInteger availableOutput = output.length - outputPosition;
+        NSUInteger remainingInput = inputLength - consumedInput;
+        _inflator.next_in = (Bytef *) (data.bytes + consumedInput);
+        _inflator.avail_in = remainingInput;
+        _inflator.next_out = output.mutableBytes + outputPosition;
+        _inflator.avail_out = availableOutput;
+        int result = inflate(&_inflator, Z_NO_FLUSH);
+        consumedInput += remainingInput - _inflator.avail_in;
+        [output setLength:outputPosition + availableOutput - _inflator.avail_out];
+        
+        // TODO: Handle buffer errors and steam_end conditions
+        if (result == Z_BUF_ERROR) {
+            continue;
+        }
+        if (result == Z_STREAM_END) {
+            //            inflateReset(&_inflator);
+            continue;
+        }
+        if (result != Z_OK) {
+            inflateEnd(&_inflator);
+            return nil;
+        }
+    }
+    
+    inflateEnd(&_inflator);
+    return output;
+}
+
+@end

--- a/Source/Socket.IO-Client-Swift-Bridging-Header.h
+++ b/Source/Socket.IO-Client-Swift-Bridging-Header.h
@@ -1,0 +1,14 @@
+//
+//  Socket.IO-Client-Swift-Bridging-Header.h
+//  Socket.IO-Client-Swift
+//
+//  Created by Danny Ricciotti on 4/8/16.
+//
+//
+
+#ifndef Socket_IO_Client_Swift_Bridging_Header_h
+#define Socket_IO_Client_Swift_Bridging_Header_h
+
+#import "DeflateHelper.h"
+
+#endif /* Socket_IO_Client_Swift_Bridging_Header_h */

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -652,7 +652,6 @@ public class WebSocket : NSObject, NSStreamDelegate {
             }
                         
             if ( shouldHandleCompression ) {
-                var datastring = NSString(data: data, encoding: NSUTF8StringEncoding)
                 if let inflatedData = inflateFrame(data) {
                     data = inflatedData
                     dataLength = (UInt64)(inflatedData.length)


### PR DESCRIPTION
This Pull Request adds support for websocket compression, which was added to Socket.io in version 1.4. This is a basic implementation which still has some outstanding issues, therefore `[DONT MERGE]` was added to the title of the issue.


-  Basic support for `Sec-WebSocket-Extensions` header and the negotiation of the `permessage-deflate` extension.
- Websocket compression using the `zlib` library. Required using an Objective-C helper class to interface with `zlib` as it wasn't possible or easy to use that library's C API from within Swift.

Remaining issues:
- [ ] Use https://github.com/tidwall/DeflateSwift or similar instead of ObjC
- [ ] Turn compression off by default and expose API to enable it.
- [ ] Verify that `response.bytesLeft -= Int(dataLength)` is correct for handling partial frames. Test when extra data is present (ie. next frame)
- [ ] Pick error code to use when compressed frames are unable to be decompressed.
- [ ] Handle error cases and TODOs in the DeflateHelper class. There are also optimizations that can be done such as not building a new inflator with each packet.
- [ ] Determine whether we should re-use the deflate context to achieve better compression. From Because the client and server may reuse their DEFLATE context between messages, the compression improves as more similar messages are sent over the connection. See https://blog.jcoglan.com/2015/03/30/websocket-extensions-as-plugins/ (`Because the client and server may reuse their DEFLATE context between messages...`)
- [ ] Requires more testing.
- [ ] Change version in Podspec
