### PR TITLE
Fixing url encoding for connect params

### DIFF
--- a/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
+++ b/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
@@ -128,6 +128,12 @@
 		74ABF7771C3991C10078C657 /* SocketIOClientSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74ABF7761C3991C10078C657 /* SocketIOClientSpec.swift */; };
 		74F124F01BC574CF002966F4 /* SocketBasicPacketTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F124EF1BC574CF002966F4 /* SocketBasicPacketTest.swift */; };
 		74F124F11BC574CF002966F4 /* SocketBasicPacketTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F124EF1BC574CF002966F4 /* SocketBasicPacketTest.swift */; };
+		CEBA56961CDA0B7700BA0389 /* NSCharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA56951CDA0B7700BA0389 /* NSCharacterSet.swift */; };
+		CEBA56971CDA0B7700BA0389 /* NSCharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA56951CDA0B7700BA0389 /* NSCharacterSet.swift */; };
+		CEBA56981CDA0B7700BA0389 /* NSCharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA56951CDA0B7700BA0389 /* NSCharacterSet.swift */; };
+		CEBA569A1CDA0B8200BA0389 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA56991CDA0B8200BA0389 /* String.swift */; };
+		CEBA569B1CDA0B8200BA0389 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA56991CDA0B8200BA0389 /* String.swift */; };
+		CEBA569C1CDA0B8200BA0389 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA56991CDA0B8200BA0389 /* String.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -195,6 +201,8 @@
 		7472C65E1BCAC46E003CA70D /* SocketSideEffectTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketSideEffectTest.swift; sourceTree = "<group>"; };
 		74ABF7761C3991C10078C657 /* SocketIOClientSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SocketIOClientSpec.swift; path = Source/SocketIOClientSpec.swift; sourceTree = "<group>"; };
 		74F124EF1BC574CF002966F4 /* SocketBasicPacketTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketBasicPacketTest.swift; sourceTree = "<group>"; };
+		CEBA56951CDA0B7700BA0389 /* NSCharacterSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSCharacterSet.swift; path = Source/NSCharacterSet.swift; sourceTree = "<group>"; };
+		CEBA56991CDA0B8200BA0389 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = String.swift; path = Source/String.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -347,6 +355,7 @@
 		5764DF7B1B51F24A004FF46E /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				CEBA569E1CDA0C0C00BA0389 /* utils */,
 				74171E501C10CD240062D398 /* SocketAckEmitter.swift */,
 				74171E511C10CD240062D398 /* SocketAckManager.swift */,
 				74171E521C10CD240062D398 /* SocketAnyEvent.swift */,
@@ -370,6 +379,15 @@
 				74171E621C10CD240062D398 /* WebSocket.swift */,
 			);
 			name = Source;
+			sourceTree = "<group>";
+		};
+		CEBA569E1CDA0C0C00BA0389 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				CEBA56951CDA0B7700BA0389 /* NSCharacterSet.swift */,
+				CEBA56991CDA0B8200BA0389 /* String.swift */,
+			);
+			name = utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -607,9 +625,11 @@
 			files = (
 				740CA1221C496EF700CB98F4 /* SocketEngineWebsocket.swift in Sources */,
 				74171EA51C10CD240062D398 /* SocketIOClientStatus.swift in Sources */,
+				CEBA569A1CDA0B8200BA0389 /* String.swift in Sources */,
 				74171E751C10CD240062D398 /* SocketEngine.swift in Sources */,
 				74171E691C10CD240062D398 /* SocketAckManager.swift in Sources */,
 				7420CB791C49629E00956AA4 /* SocketEnginePollable.swift in Sources */,
+				CEBA56961CDA0B7700BA0389 /* NSCharacterSet.swift in Sources */,
 				74ABF7771C3991C10078C657 /* SocketIOClientSpec.swift in Sources */,
 				74171E871C10CD240062D398 /* SocketEngineSpec.swift in Sources */,
 				74171E631C10CD240062D398 /* SocketAckEmitter.swift in Sources */,
@@ -664,9 +684,11 @@
 			files = (
 				740CA1211C496EF200CB98F4 /* SocketEngineWebsocket.swift in Sources */,
 				7471CCEA1C39926300364B59 /* SocketIOClientSpec.swift in Sources */,
+				CEBA569B1CDA0B8200BA0389 /* String.swift in Sources */,
 				74171EA71C10CD240062D398 /* SocketIOClientStatus.swift in Sources */,
 				74171E771C10CD240062D398 /* SocketEngine.swift in Sources */,
 				7420CB7A1C49629E00956AA4 /* SocketEnginePollable.swift in Sources */,
+				CEBA56971CDA0B7700BA0389 /* NSCharacterSet.swift in Sources */,
 				74171E6B1C10CD240062D398 /* SocketAckManager.swift in Sources */,
 				74171E891C10CD240062D398 /* SocketEngineSpec.swift in Sources */,
 				74171E651C10CD240062D398 /* SocketAckEmitter.swift in Sources */,
@@ -707,9 +729,11 @@
 			files = (
 				740CA1201C496EEB00CB98F4 /* SocketEngineWebsocket.swift in Sources */,
 				7471CCEB1C39926C00364B59 /* SocketIOClientSpec.swift in Sources */,
+				CEBA569C1CDA0B8200BA0389 /* String.swift in Sources */,
 				74171EA91C10CD240062D398 /* SocketIOClientStatus.swift in Sources */,
 				74171E791C10CD240062D398 /* SocketEngine.swift in Sources */,
 				7420CB7B1C49629E00956AA4 /* SocketEnginePollable.swift in Sources */,
+				CEBA56981CDA0B7700BA0389 /* NSCharacterSet.swift in Sources */,
 				74171E6D1C10CD240062D398 /* SocketAckManager.swift in Sources */,
 				74171E8B1C10CD240062D398 /* SocketEngineSpec.swift in Sources */,
 				74171E671C10CD240062D398 /* SocketAckEmitter.swift in Sources */,

--- a/Source/NSCharacterSet.swift
+++ b/Source/NSCharacterSet.swift
@@ -1,0 +1,31 @@
+//
+//  NSCharacterSet.swift
+//  Socket.IO-Client-Swift
+//
+//  Created by Erik Little on 9/16/15.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+extension NSCharacterSet {
+  class var allowedURLCharacterSet: NSCharacterSet {
+    return NSCharacterSet(charactersInString: "!*'();:@&=+$,/?%#[]\" {}").invertedSet
+  }
+}

--- a/Source/SocketEngine.swift
+++ b/Source/SocketEngine.swift
@@ -214,8 +214,6 @@ public final class SocketEngine : NSObject, SocketEnginePollable, SocketEngineWe
         
         urlWebSocket.path = socketPath
         urlPolling.path = socketPath
-        urlWebSocket.percentEncodedQuery = "transport=websocket"
-        urlPolling.percentEncodedQuery = "transport=polling&b64=1"
 
         if secure {
             urlPolling.scheme = "https"
@@ -234,8 +232,8 @@ public final class SocketEngine : NSObject, SocketEnginePollable, SocketEngineWe
             }
         }
 
-        urlWebSocket.percentEncodedQuery = urlWebSocket.percentEncodedQuery! + queryString
-        urlPolling.percentEncodedQuery = urlPolling.percentEncodedQuery! + queryString
+        urlWebSocket.percentEncodedQuery = "transport=websocket" + queryString
+        urlPolling.percentEncodedQuery = "transport=polling&b64=1" + queryString
         
         return (urlPolling.URL!, urlWebSocket.URL!)
     }

--- a/Source/SocketEngine.swift
+++ b/Source/SocketEngine.swift
@@ -214,8 +214,8 @@ public final class SocketEngine : NSObject, SocketEnginePollable, SocketEngineWe
         
         urlWebSocket.path = socketPath
         urlPolling.path = socketPath
-        urlWebSocket.query = "transport=websocket"
-        urlPolling.query = "transport=polling&b64=1"
+        urlWebSocket.percentEncodedQuery = "transport=websocket"
+        urlPolling.percentEncodedQuery = "transport=polling&b64=1"
 
         if secure {
             urlPolling.scheme = "https"
@@ -227,12 +227,15 @@ public final class SocketEngine : NSObject, SocketEnginePollable, SocketEngineWe
 
         if connectParams != nil {
             for (key, value) in connectParams! {
-                queryString += "&\(key)=\(value)"
+                let keyEsc   = key.urlEncode()!
+                let valueEsc = "\(value)".urlEncode()!
+
+                queryString += "&\(keyEsc)=\(valueEsc)"
             }
         }
 
-        urlWebSocket.query = urlWebSocket.query! + queryString
-        urlPolling.query = urlPolling.query! + queryString
+        urlWebSocket.percentEncodedQuery = urlWebSocket.percentEncodedQuery! + queryString
+        urlPolling.percentEncodedQuery = urlPolling.percentEncodedQuery! + queryString
         
         return (urlPolling.URL!, urlWebSocket.URL!)
     }

--- a/Source/SocketEngineSpec.swift
+++ b/Source/SocketEngineSpec.swift
@@ -63,14 +63,14 @@ import Foundation
 extension SocketEngineSpec {
     var urlPollingWithSid: NSURL {
         let com = NSURLComponents(URL: urlPolling, resolvingAgainstBaseURL: false)!
-        com.query = com.query! + "&sid=\(sid)"
+        com.percentEncodedQuery = com.percentEncodedQuery! + "&sid=\(sid.urlEncode()!)"
         
         return com.URL!
     }
     
     var urlWebSocketWithSid: NSURL {
         let com = NSURLComponents(URL: urlWebSocket, resolvingAgainstBaseURL: false)!
-        com.query = com.query! + (sid == "" ? "" : "&sid=\(sid)")
+        com.percentEncodedQuery = com.percentEncodedQuery! + (sid == "" ? "" : "&sid=\(sid.urlEncode()!)")
         
         return com.URL!
     }

--- a/Source/String.swift
+++ b/Source/String.swift
@@ -1,0 +1,31 @@
+//
+//  String.swift
+//  Socket.IO-Client-Swift
+//
+//  Created by Erik Little on 9/16/15.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+extension String {
+  func urlEncode() -> String? {
+    return self.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.allowedURLCharacterSet)
+  }
+}


### PR DESCRIPTION
Hi,

I just updated my library from v4.x to v6.x and you re-introduce an issue with the connect params url encoding.

So here is my patch.

Best