### PR TITLE
Add Proxy support for websocket

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/socketio/socket.io-client-swift.git", :tag => 'v6.1.2' }
+  s.source       = { :git => "https://github.com/oldshuren/socket.io-client-swift.git", :branch => 'proxy-connect' }
   s.source_files  = "Source/**/*.swift"
   s.requires_arc = true
   # s.dependency 'Starscream', '~> 0.9' # currently this repo includes Starscream swift files

--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/oldshuren/socket.io-client-swift.git", :branch => 'proxy-connect' }
+  s.source       = { :git => "https://github.com/oldshuren/socket.io-client-swift.git", :tag => 'proxy6.1.2' }
   s.source_files  = "Source/**/*.swift"
   s.requires_arc = true
   # s.dependency 'Starscream', '~> 0.9' # currently this repo includes Starscream swift files


### PR DESCRIPTION
This pull request add proxy support for socket.io client behind a proxy server.

The proxy configuration is getting from the system. The proxy server must support the CONNECT method.

When determined that there is proxy setting, instead of opening a network stream to the remote websocket server, it opens a network stream to the proxy server, then issuing an HTTP CONNECT request. If the proxy server responds with 200 OK, it treats this network stream as a normal stream to the remote websocket server. 