### PR TITLE
Development

### DIFF
--- a/Source/SSLSecurity.swift
+++ b/Source/SSLSecurity.swift
@@ -241,7 +241,7 @@ public class SSLSecurity : NSObject {
      
      - returns: the public keys from the certifcate chain for the trust
      */
-    func publicKeyChainForTrust(trust: SecTrustRef) -> [SecKeyRef] {
+    private func publicKeyChainForTrust(trust: SecTrustRef) -> [SecKeyRef] {
         let policy = SecPolicyCreateBasicX509()
         let keys = (0..<SecTrustGetCertificateCount(trust)).reduce([SecKeyRef]()) { (keys: [SecKeyRef], index: Int) -> [SecKeyRef] in
             var keys = keys

--- a/Source/SSLSecurity.swift
+++ b/Source/SSLSecurity.swift
@@ -55,7 +55,7 @@ public class SSLSecurity : NSObject {
     
     var isReady = false //is the key processing done?
     var certificates: [NSData]? //the certificates
-    var pubKeys: [SecKeyRef]? //the public keys
+    private var pubKeys: [SecKeyRef]? //the public keys
     var usePublicKeys = false //use public keys or certificate validation?
     
     /**


### PR DESCRIPTION
I have an Objective-C framework project which uses socket.io. I then have an Objective-C app project that uses the framework project (but not socket.io directly). Both projects use carthage to handle dependencies. 

When I do a carthage update of the framework project,everything compiles fine.

When I do a carthage update of the app project, the compile of socket.io fails because it is unable to put a SecKeyRef struct into an NSArray. 

This pull request makes a method that returns a `[Seckeyref]` and a property of type `[SecKeyRef]` private so that they are removed from the generated Objective-C header file. So far this seems to have fixed my compilation problem.