### PR TITLE
Modify mac version base mac os 10.9

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT' }
   s.author       = { "Erik" => "nuclear.ace@gmail.com" }
   s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.10'
+  s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
   s.source       = { :git => "https://github.com/socketio/socket.io-client-swift.git", :tag => 'v7.0.3' }
   s.source_files  = "Source/**/*.swift"


### PR DESCRIPTION
Modified mac os support version for 10.9 , I have test passed socket.io-mac target  on mac os 10.9 . 
cause our project use socket.io-swift , but we need support os x 10.9 , so , the best way is modify the support target in your open source . please merge it , appreciated. 
