### PR TITLE
fix Use Legacy Swift issue

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -17,5 +17,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/socketio/socket.io-client-swift.git", :tag => 'v8.0.2' }
   s.source_files  = "Source/**/*.swift"
   s.requires_arc = true
+  s.pod_target_xcconfig = {'SWIFT_VERSION' => '3.0'}
   # s.dependency 'Starscream', '~> 0.9' # currently this repo includes Starscream swift files
 end


### PR DESCRIPTION
fix the following error:

```
Check dependencies
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
```