### PR TITLE
synchronized call to mutating ackHandlers.executeAck

### DIFF
--- a/Source/SocketIOClient.swift
+++ b/Source/SocketIOClient.swift
@@ -54,6 +54,7 @@ public final class SocketIOClient : NSObject, SocketEngineClient, SocketParsable
     private var handlers = [SocketEventHandler]()
     private var reconnecting = false
 
+    private let semaphore = DispatchSemaphore(value: 1)
     private(set) var currentAck = -1
     private(set) var handleQueue = DispatchQueue.main
     private(set) var reconnectAttempts = -1
@@ -161,10 +162,15 @@ public final class SocketIOClient : NSObject, SocketEngineClient, SocketParsable
         }
     }
 
-    private func createOnAck(_ items: [Any]) -> OnAckCallback {
+    private func nextAck() -> Int {
+        semaphore.wait()
+        defer { semaphore.signal() }
         currentAck += 1
-        
-        return OnAckCallback(ackNumber: currentAck, items: items, socket: self)
+        return currentAck
+    }
+
+    private func createOnAck(_ items: [Any]) -> OnAckCallback {
+        return OnAckCallback(ackNumber: nextAck(), items: items, socket: self)
     }
 
     func didConnect() {


### PR DESCRIPTION
helps with memory issues of socketio/socket.io-client-swift#89

There's no need to executeAck async because it is async internally, but dangerous because it's mutating