### PR TITLE
Thread safety issues

### DIFF
--- a/Source/SocketIOClient.swift
+++ b/Source/SocketIOClient.swift
@@ -54,6 +54,7 @@ public final class SocketIOClient : NSObject, SocketEngineClient, SocketParsable
     private var handlers = [SocketEventHandler]()
     private var reconnecting = false
 
+    private let semaphore = DispatchSemaphore(value: 1)
     private(set) var currentAck = -1
     private(set) var handleQueue = DispatchQueue.main
     private(set) var reconnectAttempts = -1
@@ -161,10 +162,15 @@ public final class SocketIOClient : NSObject, SocketEngineClient, SocketParsable
         }
     }
 
-    private func createOnAck(_ items: [Any]) -> OnAckCallback {
+    private func nextAck() -> Int {
+        semaphore.wait()
+        defer { semaphore.signal() }
         currentAck += 1
-        
-        return OnAckCallback(ackNumber: currentAck, items: items, socket: self)
+        return currentAck
+    }
+
+    private func createOnAck(_ items: [Any]) -> OnAckCallback {
+        return OnAckCallback(ackNumber: nextAck(), items: items, socket: self)
     }
 
     func didConnect() {


### PR DESCRIPTION
I have found that emitting from 1000 async NSOperations within a NSOperationQueue which has maxConcurrentOperationCount = 25 leads to about 20 acks won't be called back due to not safe incrementing of SocketIOClient private currentAck.