### PR TITLE
Update SocketIOClient.swift

### DIFF
--- a/Source/SocketIOClient.swift
+++ b/Source/SocketIOClient.swift
@@ -78,6 +78,10 @@ public final class SocketIOClient : NSObject, SocketEngineClient, SocketParsable
             self.config.insert(.secure(true))
         }
         
+        if !socketURL.path.isEmpty {
+            self.nsp = socketURL.path
+        }
+
         for option in config {
             switch option {
             case let .reconnects(reconnects):


### PR DESCRIPTION
With this change the swift library will have the same behavior of the Java version. When you whant to create a socket client that have namespace on Java you just create a Socket-IO object.

So, if you inform something like "http://your_ip:your_port/path"

It will use your path as a namespace.