### PR TITLE
v11.1.0

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
       'SWIFT_VERSION' => '3.1'
   }
   s.source_files  = "Source/*.swift"
-  s.dependency "StarscreamSocketIO", "~> 8.0.2"
+  s.dependency "StarscreamSocketIO", "~> 8.0.3"
 end

--- a/SocketIO-MacTests/SocketSideEffectTest.swift
+++ b/SocketIO-MacTests/SocketSideEffectTest.swift
@@ -83,6 +83,22 @@ class SocketSideEffectTest: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testHandleOnceClientEvent() {
+        let expect = expectation(description: "handled event")
+
+        socket.once(clientEvent: .connect) {data, ack in
+            XCTAssertEqual(self.socket.testHandlers.count, 0)
+            expect.fulfill()
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            // Fake connecting
+            self.socket.parseEngineMessage("0/")
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     func testOffWithEvent() {
         socket.on("test") {data, ack in }
         socket.on("test") {data, ack in }

--- a/SocketIO-MacTests/SocketSideEffectTest.swift
+++ b/SocketIO-MacTests/SocketSideEffectTest.swift
@@ -85,11 +85,19 @@ class SocketSideEffectTest: XCTestCase {
 
     func testOffWithEvent() {
         socket.on("test") {data, ack in }
-        XCTAssertEqual(socket.testHandlers.count, 1)
         socket.on("test") {data, ack in }
         XCTAssertEqual(socket.testHandlers.count, 2)
         socket.off("test")
         XCTAssertEqual(socket.testHandlers.count, 0)
+    }
+
+    func testOffClientEvent() {
+        socket.on(clientEvent: .connect) {data, ack in }
+        socket.on(clientEvent: .disconnect) {data, ack in }
+        XCTAssertEqual(socket.testHandlers.count, 2)
+        socket.off(clientEvent: .disconnect)
+        XCTAssertEqual(socket.testHandlers.count, 1)
+        XCTAssertTrue(socket.testHandlers.contains(where: { $0.event == "connect" }))
     }
 
     func testOffWithId() {

--- a/Source/SocketIOClient.swift
+++ b/Source/SocketIOClient.swift
@@ -439,6 +439,15 @@ open class SocketIOClient : NSObject, SocketIOClientSpec, SocketEngineClient, So
         }
     }
 
+    /// Removes handler(s) for a client event.
+    ///
+    /// If you wish to remove a client event handler, call the `off(id:)` with the UUID received from its `on` call.
+    ///
+    /// - parameter clientEvent: The event to remove handlers for.
+    open func off(clientEvent event: SocketClientEvent) {
+        off(event.rawValue)
+    }
+
     /// Removes handler(s) based on an event name.
     ///
     /// If you wish to remove a specific event, call the `off(id:)` with the UUID received from its `on` call.

--- a/Source/SocketIOClient.swift
+++ b/Source/SocketIOClient.swift
@@ -508,6 +508,16 @@ open class SocketIOClient : NSObject, SocketIOClientSpec, SocketEngineClient, So
         return handler.id
     }
 
+    /// Adds a single-use handler for a client event.
+    ///
+    /// - parameter clientEvent: The event for this handler.
+    /// - parameter callback: The callback that will execute when this event is received.
+    /// - returns: A unique id for the handler that can be used to remove it.
+    @discardableResult
+    open func once(clientEvent event: SocketClientEvent, callback: @escaping NormalCallback) -> UUID {
+        return once(event.rawValue, callback: callback)
+    }
+
     /// Adds a single-use handler for an event.
     ///
     /// - parameter event: The event name for this handler.


### PR DESCRIPTION
- Adds `off(clientEvent:)` and `once(clientEvent:callback:)` methods.
- Hopefully fixes conflicting system modules from Starscream