### PR TITLE
Big bug in some linux versions was fixed. For example, in my Ubuntu 1…

### DIFF
--- a/Source/SocketIO/Parse/SocketParsable.swift
+++ b/Source/SocketIO/Parse/SocketParsable.swift
@@ -113,7 +113,7 @@ extension SocketParsable where Self: SocketIOClientSpec {
             }
         }
 
-        var dataArray = String(message.utf16[message.utf16.index(reader.currentIndex, offsetBy: 1)..<message.utf16.endIndex])!
+        var dataArray = "\(message.utf16[message.utf16.index(reader.currentIndex, offsetBy: 1)..<message.utf16.endIndex])"
 
         if type == .error && !dataArray.hasPrefix("[") && !dataArray.hasSuffix("]") {
             dataArray = "[" + dataArray + "]"

--- a/Source/SocketIO/Util/SocketStringReader.swift
+++ b/Source/SocketIO/Util/SocketStringReader.swift
@@ -46,7 +46,7 @@ struct SocketStringReader {
     }
 
     mutating func read(count: Int) -> String {
-        let readString = String(message.utf16[currentIndex..<message.utf16.index(currentIndex, offsetBy: count)])!
+        let readString = "\(message.utf16[currentIndex..<message.utf16.index(currentIndex, offsetBy: count)])"
 
         advance(by: count)
 


### PR DESCRIPTION
…6.04.2 and 16.10 with swift 4.0.2 substring of "0" is equal to "4", substring of "[authenticated: true]" is equal to "[authenticated: true"