### PR TITLE
Add missing `,`  when leaving or joining a namespace

### DIFF
--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -205,7 +205,7 @@ open class SocketManager : NSObject, SocketManagerSpec, SocketParsable, SocketDa
             return
         }
 
-        engine?.send("0\(socket.nsp)", withData: [])
+        engine?.send("0\(socket.nsp),", withData: [])
     }
 
     /// Called when the manager has disconnected from socket.io.
@@ -233,7 +233,7 @@ open class SocketManager : NSObject, SocketManagerSpec, SocketParsable, SocketDa
     ///
     /// - parameter socket: The socket to disconnect.
     open func disconnectSocket(_ socket: SocketIOClient) {
-        engine?.send("1\(socket.nsp)", withData: [])
+        engine?.send("1\(socket.nsp),", withData: [])
         socket.didDisconnect(reason: "Namespace leave")
     }
 


### PR DESCRIPTION
if a comma does not follow the namespace, a server will throw : 

play.socketio.protocol.SocketIOEncodingException: Error decoding socket IO packet '0/api/v1/chats/8b52ca9c-aa28-4b5e-b59c-44129d3142eb': Expected ',' to end namespace declaration

As for events, join and leave namespace  should be suffixed by a comma