### PR TITLE
thread-safe ackNumber generation and memory leak fix

### DIFF
--- a/Source/SocketIO/Ack/SocketAckEmitter.swift
+++ b/Source/SocketIO/Ack/SocketAckEmitter.swift
@@ -135,10 +135,14 @@ public final class OnAckCallback : NSObject {
 
         guard seconds != 0 else { return }
 
-        socket.manager?.handleQueue.asyncAfter(deadline: DispatchTime.now() + seconds) {[weak socket] in
+        socket.manager?.handleQueue.asyncAfter(deadline: DispatchTime.now() + seconds) {
+            [weak self, weak socket] in
+            
             guard let socket = socket else { return }
-
-            socket.ackHandlers.timeoutAck(self.ackNumber)
+            guard let me:OnAckCallback = self else { return }
+            
+            socket.ackHandlers.timeoutAck(me.ackNumber)
+            
         }
     }
 


### PR DESCRIPTION
1. ack number generation without semaphores is failing under heavy load (1000+ emits from a concurrent queue)
2. without weak self in timeout callback it retains the callbacks if timeout > 0