### PR TITLE
Add enableSOCKSProxy option to pass to Starscream WebSockets

### DIFF
--- a/Source/SocketIO/Client/SocketIOClientOption.swift
+++ b/Source/SocketIO/Client/SocketIOClientOption.swift
@@ -52,6 +52,9 @@ public enum SocketIOClientOption : ClientOption {
 
     /// If passed `true`, the only transport that will be used will be WebSockets.
     case forceWebsockets(Bool)
+    
+    /// If passed `true`, the WebSocket stream will be configured with the enableSOCKSProxy `true`.
+    case enableSOCKSProxy(Bool)
 
     /// The queue that all interaction with the client should occur on. This is the queue that event handlers are
     /// called on.
@@ -133,6 +136,8 @@ public enum SocketIOClientOption : ClientOption {
             description = "security"
         case .sessionDelegate:
             description = "sessionDelegate"
+        case .enableSOCKSProxy:
+            description = "enableSOCKSProxy"
         }
 
         return description
@@ -178,6 +183,8 @@ public enum SocketIOClientOption : ClientOption {
             value = signed
         case let .sessionDelegate(delegate):
             value = delegate
+        case let .enableSOCKSProxy(enable):
+            value = enable
         }
 
         return value

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -113,6 +113,9 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
     /// If `true`, then the engine is currently in WebSockets mode.
     @available(*, deprecated, message: "No longer needed, if we're not polling, then we must be doing websockets")
     public private(set) var websocket = false
+    
+    /// When `true`, the WebSocket `stream` will be configured with the enableSOCKSProxy `true`.
+    public private(set) var enableSOCKSProxy = false
 
     /// The WebSocket for this engine.
     public private(set) var ws: WebSocket?
@@ -283,7 +286,9 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
 
         addHeaders(to: &req)
 
-        ws = WebSocket(request: req)
+        let stream = FoundationStream()
+        stream.enableSOCKSProxy = enableSOCKSProxy
+        ws = WebSocket(request: req, stream: stream)
         ws?.callbackQueue = engineQueue
         ws?.enableCompression = compress
         ws?.disableSSLCertValidation = selfSigned
@@ -588,6 +593,8 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
                 self.security = security
             case .compress:
                 self.compress = true
+            case .enableSOCKSProxy:
+                self.enableSOCKSProxy = true
             default:
                 continue
             }

--- a/Source/SocketIO/Util/SocketExtensions.swift
+++ b/Source/SocketIO/Util/SocketExtensions.swift
@@ -81,6 +81,8 @@ extension Dictionary where Key == String, Value == Any {
             return .sessionDelegate(delegate)
         case let ("compress", compress as Bool):
             return compress ? .compress : nil
+        case let ("enableSOCKSProxy", enable as Bool):
+            return .enableSOCKSProxy(enable)
         default:
             return nil
         }


### PR DESCRIPTION
This PR creates a new SocketIOClientConfiguration option called enableSOCKSProxy, this option is passed through to the Starscream WebSockets object initialization.