### PR TITLE
Fix for SyntaxError: Unexpected end of JSON input

### DIFF
--- a/Source/SocketIO/Engine/SocketEnginePollable.swift
+++ b/Source/SocketIO/Engine/SocketEnginePollable.swift
@@ -214,12 +214,6 @@ extension SocketEnginePollable {
 
         postWait.append(String(type.rawValue) + message)
 
-        for data in datas {
-            if case let .right(bin) = createBinaryDataForSend(using: data) {
-                postWait.append(bin)
-            }
-        }
-
         if !waitingForPost {
             flushWaitingForPost()
         }


### PR DESCRIPTION
**Engine.io throwing error 'invalid JSON' **

Hi, thanks for this great library! I've been using it in multiple projects and I'm very happy with it!

I have an issue with the code omitted in this PR, I'm submitting this change to illustrate the fix that worked for me, if this bug & fix make sense to you, maybe we can come up with a better solution together.

Note:
that I am using Engine.IO server side and on my iOS client I'm extending SocketEngineClient class and using SocketEngineSpec to emit messages.
`self.engine?.write(jsonMessage, withType: .message, withData: [Data()])`   

My Issue
---------
The code omitted in this PR is sending an invalid JSON to my Engine.IO based server, this is happening regularly during a session, Engine.IO on server side, is throwing error: `SyntaxError: Unexpected end of JSON input` error.
I'd also like to point out that removing this code has no affect on server-client communication (at least that I know of).

An explanation of why exactly is this happening should be very much appreciated (: 

My Setup
---------
- Socket.IO swift 13.2.1  
- Engine.IO 3.1.3 (server side)

If there's any other info I can provide please let me know,
Thanks again for this library!