### PR TITLE
fix cookies import when create the websocket

### DIFF
--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -281,7 +281,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
     private func createWebSocketAndConnect() {
         var req = URLRequest(url: urlWebSocketWithSid)
 
-        addHeaders(to: &req, includingCookies: session?.configuration.httpCookieStorage?.cookies)
+        addHeaders(to: &req, includingCookies: session?.configuration.httpCookieStorage?.cookies(for: urlWebSocketWithSid))
 
         ws = WebSocket(request: req)
         ws?.callbackQueue = engineQueue

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -281,7 +281,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
     private func createWebSocketAndConnect() {
         var req = URLRequest(url: urlWebSocketWithSid)
 
-        addHeaders(to: &req, includingCookies: session?.configuration.httpCookieStorage?.cookies(for: urlWebSocketWithSid))
+        addHeaders(to: &req, includingCookies: session?.configuration.httpCookieStorage?.cookies(for: urlPollingWithSid))
 
         ws = WebSocket(request: req)
         ws?.callbackQueue = engineQueue


### PR DESCRIPTION
The upgrade to web socket should import only cookies relative to the url.
Without this specify, all cookies are imported and in my case it never upgrade to web socket (because there are several cookies in header that does not match the session)