### PR TITLE
Propagate http header callback from websocket back to client.

### DIFF
--- a/Source/SocketIO/Client/SocketIOClientSpec.swift
+++ b/Source/SocketIO/Client/SocketIOClientSpec.swift
@@ -344,4 +344,16 @@ public enum SocketClientEvent : String {
     /// }
     /// ```
     case statusChange
+
+    /// Emitted when when upgrading the http connection to a websocket connection.
+    ///
+    /// Usage:
+    ///
+    /// ```swift
+    /// socket.on(clientEvent: .websocketUpgrade) {data, ack in
+    ///     let headers = (data as [Any])[0]
+    ///     // Some header logic
+    /// }
+    /// ```
+    case websocketUpgrade
 }

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -316,7 +316,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
         ws?.onHttpResponseHeaders = {[weak self] headers in
             guard let this = self else { return }
 
-            this.client?.engineOnWebsocketUpgrade(headers: headers)
+            this.client?.engineDidWebsocketUpgrade(headers: headers)
         }
 
         ws?.connect()

--- a/Source/SocketIO/Engine/SocketEngineClient.swift
+++ b/Source/SocketIO/Engine/SocketEngineClient.swift
@@ -59,4 +59,9 @@ import Foundation
     ///
     /// - parameter data: The data the engine received.
     func parseEngineBinaryData(_ data: Data)
+
+    /// Called when when upgrading the http connection to a websocket connection.
+    ///
+    /// - parameter headers: The http headers.
+    func engineDidWebsocketUpgrade(headers: [String: String])
 }

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -386,7 +386,7 @@ open class SocketManager : NSObject, SocketManagerSpec, SocketParsable, SocketDa
         }
     }
      private func _engineDidWebsocketUpgrade(headers: [String: String]) {
-        emitAll(clientEvent: .httpResponseHeaders, data: [headers])
+        emitAll(clientEvent: .websocketUpgrade, data: [headers])
     }
 
     /// Called when the engine has a message that must be parsed.

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -377,6 +377,18 @@ open class SocketManager : NSObject, SocketManagerSpec, SocketParsable, SocketDa
         }
     }
 
+    /// Called when when upgrading the http connection to a websocket connection.
+    ///
+    /// - parameter headers: The http headers.
+    open func engineDidWebsocketUpgrade(headers: [String: String]) {
+        handleQueue.async {
+            self._engineDidWebsocketUpgrade(headers: headers)
+        }
+    }
+     private func _engineDidWebsocketUpgrade(headers: [String: String]) {
+        emitAll(clientEvent: .httpResponseHeaders, data: [headers])
+    }
+
     /// Called when the engine has a message that must be parsed.
     ///
     /// - parameter msg: The message that needs parsing.


### PR DESCRIPTION
On Socket.IO Android we already have this callback, so backport it to iOS.
Also note that we need the current (unreleased) version of Starscream (master branch commit 0f18ae5959b2ff9940b5bc50a4f770f4c38bbd2f) to run it.