### PR TITLE
Don’t create empty closures when we don’t need them

### DIFF
--- a/Source/SocketIO/Client/SocketIOClient.swift
+++ b/Source/SocketIO/Client/SocketIOClient.swift
@@ -204,25 +204,7 @@ open class SocketIOClient : NSObject, SocketIOClientSpec {
         leaveNamespace()
     }
 
-    /// Send an event to the server, with optional data items.
-    ///
-    /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
-    /// will be emitted. The structure of the error data is `[eventName, items, theError]`
-    ///
-    /// - parameter event: The event to send.
-    /// - parameter items: The items to send with this event. May be left out.
-    open func emit(_ event: String, _ items: SocketData...) {
-        do {
-            try emit(event, with: items.map({ try $0.socketRepresentation() }))
-        } catch {
-            DefaultSocketLogger.Logger.error("Error creating socketRepresentation for emit: \(event), \(items)",
-                                             type: logType)
-
-            handleClientEvent(.error, data: [event, items, error])
-        }
-    }
-
-    /// Send an event to the server, with optional data items and write completion handler.
+    /// Send an event to the server, with optional data items and optional write completion handler.
     ///
     /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
     /// will be emitted. The structure of the error data is `[eventName, items, theError]`

--- a/Source/SocketIO/Client/SocketIOClient.swift
+++ b/Source/SocketIO/Client/SocketIOClient.swift
@@ -230,7 +230,7 @@ open class SocketIOClient : NSObject, SocketIOClientSpec {
     /// - parameter event: The event to send.
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
-    open func emit(_ event: String, _ items: SocketData..., completion: @escaping (() -> ())? = nil)  {
+    open func emit(_ event: String, _ items: SocketData..., completion: (() -> ())? = nil)  {
         do {
             try emit(event, with: items.map({ try $0.socketRepresentation() }), completion: completion)
         } catch {
@@ -256,7 +256,7 @@ open class SocketIOClient : NSObject, SocketIOClientSpec {
     /// - parameter items: The items to send with this event. Send an empty array to send no data.
     /// - parameter completion: Callback called on transport write completion.
     @objc
-    open func emit(_ event: String, with items: [Any], completion: @escaping (() -> ())? = nil) {
+    open func emit(_ event: String, with items: [Any], completion: (() -> ())? = nil) {
         emit([event] + items, completion: completion)
     }
 
@@ -317,13 +317,13 @@ open class SocketIOClient : NSObject, SocketIOClientSpec {
               ack: Int? = nil,
               binary: Bool = true,
               isAck: Bool = false,
-              completion: @escaping (() -> ())? = nil
+              completion: (() -> ())? = nil
     ) {
         // wrap the completion handler so it always runs async via handlerQueue
         let wrappedCompletion: (() -> ())? = (completion == nil) ? nil : {[weak self] in
             guard let this = self else { return }
             this.manager?.handleQueue.async {
-                completion()
+                completion!()
             }
         }
 

--- a/Source/SocketIO/Client/SocketIOClientSpec.swift
+++ b/Source/SocketIO/Client/SocketIOClientSpec.swift
@@ -109,7 +109,7 @@ public protocol SocketIOClientSpec : AnyObject {
     /// - parameter event: The event to send.
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
-    func emit(_ event: String, _ items: SocketData..., completion: @escaping () -> ())
+    func emit(_ event: String, _ items: SocketData..., completion: @escaping (() -> ())? = nil)
 
     /// Call when you wish to tell the server that you've received the event for `ack`.
     ///

--- a/Source/SocketIO/Client/SocketIOClientSpec.swift
+++ b/Source/SocketIO/Client/SocketIOClientSpec.swift
@@ -109,7 +109,7 @@ public protocol SocketIOClientSpec : AnyObject {
     /// - parameter event: The event to send.
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
-    func emit(_ event: String, _ items: SocketData..., completion: @escaping (() -> ())? = nil)
+    func emit(_ event: String, _ items: SocketData..., completion: (() -> ())?)
 
     /// Call when you wish to tell the server that you've received the event for `ack`.
     ///

--- a/Source/SocketIO/Client/SocketIOClientSpec.swift
+++ b/Source/SocketIO/Client/SocketIOClientSpec.swift
@@ -92,16 +92,7 @@ public protocol SocketIOClientSpec : AnyObject {
     /// Disconnects the socket.
     func disconnect()
 
-    /// Send an event to the server, with optional data items.
-    ///
-    /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
-    /// will be emitted. The structure of the error data is `[eventName, items, theError]`
-    ///
-    /// - parameter event: The event to send.
-    /// - parameter items: The items to send with this event. May be left out.
-    func emit(_ event: String, _ items: SocketData...)
-
-    /// Send an event to the server, with optional data items and write completion handler.
+    /// Send an event to the server, with optional data items and optional write completion handler.
     ///
     /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
     /// will be emitted. The structure of the error data is `[eventName, items, theError]`

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -617,7 +617,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
     /// - parameter type: The type of this message.
     /// - parameter data: Any data that this message has.
     /// - parameter completion: Callback called on transport write completion.
-    open func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping (() -> ())? = nil) {
+    open func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: (() -> ())? = nil) {
         engineQueue.async {
             guard self.connected else {
                 completion?()

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -346,7 +346,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
         if polling {
             disconnectPolling(reason: reason)
         } else {
-            sendWebSocketMessage("", withType: .close, withData: [], completion: {})
+            sendWebSocketMessage("", withType: .close, withData: [], completion: nil)
             closeOutEngine(reason: reason)
         }
     }
@@ -372,7 +372,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
 
         DefaultSocketLogger.Logger.log("Switching to WebSockets", type: SocketEngine.logType)
 
-        sendWebSocketMessage("", withType: .upgrade, withData: [], completion: {})
+        sendWebSocketMessage("", withType: .upgrade, withData: [], completion: nil)
         polling = false
         fastUpgrade = false
         probing = false
@@ -390,7 +390,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
         DefaultSocketLogger.Logger.log("Flushing probe wait", type: SocketEngine.logType)
 
         for waiter in probeWait {
-            write(waiter.msg, withType: waiter.type, withData: waiter.data, completion:waiter.completion)
+            write(waiter.msg, withType: waiter.type, withData: waiter.data, completion: waiter.completion)
         }
 
         probeWait.removeAll(keepingCapacity: false)
@@ -550,7 +550,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
         }
 
         pongsMissed += 1
-        write("", withType: .ping, withData: [], completion: {})
+        write("", withType: .ping, withData: [], completion: nil)
 
         engineQueue.asyncAfter(deadline: .now() + .milliseconds(pingInterval)) {[weak self, id = self.sid] in
             // Make sure not to ping old connections
@@ -606,7 +606,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
             DefaultSocketLogger.Logger.log("Upgrading transport to WebSockets", type: SocketEngine.logType)
 
             fastUpgrade = true
-            sendPollMessage("", withType: .noop, withData: [], completion: {})
+            sendPollMessage("", withType: .noop, withData: [], completion: nil)
             // After this point, we should not send anymore polling messages
         }
     }
@@ -617,10 +617,10 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
     /// - parameter type: The type of this message.
     /// - parameter data: Any data that this message has.
     /// - parameter completion: Callback called on transport write completion.
-    open func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping () -> ()) {
+    open func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping (() -> ())? = nil) {
         engineQueue.async {
             guard self.connected else {
-                completion()
+                completion?()
                 return
             }
             guard !self.probing else {

--- a/Source/SocketIO/Engine/SocketEnginePollable.swift
+++ b/Source/SocketIO/Engine/SocketEnginePollable.swift
@@ -65,7 +65,7 @@ public protocol SocketEnginePollable : SocketEngineSpec {
     /// - parameter message: The message to send.
     /// - parameter withType: The type of message to send.
     /// - parameter withData: The data associated with this message.
-    func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: @escaping () -> ())
+    func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: @escaping (() -> ())?)
 
     /// Call to stop polling and invalidate the URLSession.
     func stopPolling()
@@ -75,7 +75,7 @@ public protocol SocketEnginePollable : SocketEngineSpec {
 extension SocketEnginePollable {
     func createRequestForPostWithPostWait() -> URLRequest {
         defer {
-            for packet in postWait { packet.completion() }
+            for packet in postWait { packet.completion?() }
             postWait.removeAll(keepingCapacity: true)
         }
 
@@ -219,7 +219,7 @@ extension SocketEnginePollable {
     /// - parameter withType: The type of message to send.
     /// - parameter withData: The data associated with this message.
     /// - parameter completion: Callback called on transport write completion.
-    public func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: @escaping () -> ()) {
+    public func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: @escaping (() -> ())? = nil) {
         DefaultSocketLogger.Logger.log("Sending poll: \(message) as type: \(type.rawValue)", type: "SocketEnginePolling")
 
         postWait.append((String(type.rawValue) + message, completion))

--- a/Source/SocketIO/Engine/SocketEnginePollable.swift
+++ b/Source/SocketIO/Engine/SocketEnginePollable.swift
@@ -65,7 +65,7 @@ public protocol SocketEnginePollable : SocketEngineSpec {
     /// - parameter message: The message to send.
     /// - parameter withType: The type of message to send.
     /// - parameter withData: The data associated with this message.
-    func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: @escaping (() -> ())?)
+    func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: (() -> ())?)
 
     /// Call to stop polling and invalidate the URLSession.
     func stopPolling()
@@ -219,7 +219,7 @@ extension SocketEnginePollable {
     /// - parameter withType: The type of message to send.
     /// - parameter withData: The data associated with this message.
     /// - parameter completion: Callback called on transport write completion.
-    public func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: @escaping (() -> ())? = nil) {
+    public func sendPollMessage(_ message: String, withType type: SocketEnginePacketType, withData datas: [Data], completion: (() -> ())? = nil) {
         DefaultSocketLogger.Logger.log("Sending poll: \(message) as type: \(type.rawValue)", type: "SocketEnginePolling")
 
         postWait.append((String(type.rawValue) + message, completion))

--- a/Source/SocketIO/Engine/SocketEngineSpec.swift
+++ b/Source/SocketIO/Engine/SocketEngineSpec.swift
@@ -138,7 +138,7 @@ import Starscream
     /// - parameter type: The type of this message.
     /// - parameter data: Any data that this message has.
     /// - parameter completion: Callback called on transport write completion.
-    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping (() -> ())?)
+    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: (() -> ())?)
 }
 
 extension SocketEngineSpec {
@@ -180,7 +180,7 @@ extension SocketEngineSpec {
     }
 
     /// Send an engine message (4)
-    func send(_ msg: String, withData datas: [Data], completion: @escaping (() -> ())? = nil) {
+    func send(_ msg: String, withData datas: [Data], completion: (() -> ())? = nil) {
         write(msg, withType: .message, withData: datas, completion: completion)
     }
 }

--- a/Source/SocketIO/Engine/SocketEngineSpec.swift
+++ b/Source/SocketIO/Engine/SocketEngineSpec.swift
@@ -138,7 +138,7 @@ import Starscream
     /// - parameter type: The type of this message.
     /// - parameter data: Any data that this message has.
     /// - parameter completion: Callback called on transport write completion.
-    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping () -> ())
+    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping (() -> ())?)
 }
 
 extension SocketEngineSpec {
@@ -180,7 +180,7 @@ extension SocketEngineSpec {
     }
 
     /// Send an engine message (4)
-    func send(_ msg: String, withData datas: [Data], completion: @escaping () -> () = {}) {
+    func send(_ msg: String, withData datas: [Data], completion: @escaping (() -> ())? = nil) {
         write(msg, withType: .message, withData: datas, completion: completion)
     }
 }

--- a/Source/SocketIO/Engine/SocketEngineWebsocket.swift
+++ b/Source/SocketIO/Engine/SocketEngineWebsocket.swift
@@ -41,14 +41,14 @@ public protocol SocketEngineWebsocket : SocketEngineSpec {
     func sendWebSocketMessage(_ str: String,
                               withType type: SocketEnginePacketType,
                               withData datas: [Data],
-                              completion: @escaping () -> ())
+                              completion: @escaping (() -> ())?)
 }
 
 // WebSocket methods
 extension SocketEngineWebsocket {
     func probeWebSocket() {
         if ws?.isConnected ?? false {
-            sendWebSocketMessage("probe", withType: .ping, withData: [], completion: {})
+            sendWebSocketMessage("probe", withType: .ping, withData: [], completion: nil)
         }
     }
 
@@ -63,7 +63,7 @@ extension SocketEngineWebsocket {
     public func sendWebSocketMessage(_ str: String,
                                      withType type: SocketEnginePacketType,
                                      withData datas: [Data],
-                                     completion: @escaping () -> ()
+                                     completion: @escaping (() -> ())?
     ) {
         DefaultSocketLogger.Logger.log("Sending ws: \(str) as type: \(type.rawValue)", type: "SocketEngineWebSocket")
 

--- a/Source/SocketIO/Engine/SocketEngineWebsocket.swift
+++ b/Source/SocketIO/Engine/SocketEngineWebsocket.swift
@@ -41,7 +41,7 @@ public protocol SocketEngineWebsocket : SocketEngineSpec {
     func sendWebSocketMessage(_ str: String,
                               withType type: SocketEnginePacketType,
                               withData datas: [Data],
-                              completion: @escaping (() -> ())?)
+                              completion: (() -> ())?)
 }
 
 // WebSocket methods
@@ -63,7 +63,7 @@ extension SocketEngineWebsocket {
     public func sendWebSocketMessage(_ str: String,
                                      withType type: SocketEnginePacketType,
                                      withData datas: [Data],
-                                     completion: @escaping (() -> ())?
+                                     completion: (() -> ())?
     ) {
         DefaultSocketLogger.Logger.log("Sending ws: \(str) as type: \(type.rawValue)", type: "SocketEngineWebSocket")
 

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -286,7 +286,7 @@ open class SocketManager : NSObject, SocketManagerSpec, SocketParsable, SocketDa
     /// - parameter items: The data to send with this event.
     open func emitAll(_ event: String, withItems items: [Any]) {
         forAll {socket in
-            socket.emit(event, with: items, completion: {})
+            socket.emit(event, with: items, completion: nil)
         }
     }
 

--- a/Source/SocketIO/Util/SocketTypes.swift
+++ b/Source/SocketIO/Util/SocketTypes.swift
@@ -74,10 +74,10 @@ public typealias AckCallback = ([Any]) -> ()
 public typealias NormalCallback = ([Any], SocketAckEmitter) -> ()
 
 /// A typealias for a queued POST
-public typealias Post = (msg: String, completion: (() -> ()))
+public typealias Post = (msg: String, completion: (() -> ())?)
 
 typealias JSON = [String: Any]
-typealias Probe = (msg: String, type: SocketEnginePacketType, data: [Data], completion: (() -> ()))
+typealias Probe = (msg: String, type: SocketEnginePacketType, data: [Data], completion: (() -> ())?)
 typealias ProbeWaitQueue = [Probe]
 
 enum Either<E, V> {

--- a/Tests/TestSocketIO/SocketMangerTest.swift
+++ b/Tests/TestSocketIO/SocketMangerTest.swift
@@ -198,7 +198,7 @@ public class TestSocket : SocketIOClient {
         super.didDisconnect(reason: reason)
     }
 
-    public override func emit(_ event: String, with items: [Any], completion: @escaping (() -> ())?) {
+    public override func emit(_ event: String, with items: [Any], completion: (() -> ())?) {
         expectations[ManagerExpectation.emitAllEventCalled]?.fulfill()
         expectations[ManagerExpectation.emitAllEventCalled] = nil
 

--- a/Tests/TestSocketIO/SocketMangerTest.swift
+++ b/Tests/TestSocketIO/SocketMangerTest.swift
@@ -198,7 +198,7 @@ public class TestSocket : SocketIOClient {
         super.didDisconnect(reason: reason)
     }
 
-    public override func emit(_ event: String, with items: [Any], completion: @escaping () -> ()) {
+    public override func emit(_ event: String, with items: [Any], completion: @escaping (() -> ())?) {
         expectations[ManagerExpectation.emitAllEventCalled]?.fulfill()
         expectations[ManagerExpectation.emitAllEventCalled] = nil
 

--- a/Tests/TestSocketIO/SocketSideEffectTest.swift
+++ b/Tests/TestSocketIO/SocketSideEffectTest.swift
@@ -511,5 +511,5 @@ class TestEngine : SocketEngineSpec {
     func flushWaitingForPostToWebSocket() { }
     func parseEngineData(_ data: Data) { }
     func parseEngineMessage(_ message: String) { }
-    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping () -> ()) { }
+    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping (() -> ())?) { }
 }

--- a/Tests/TestSocketIO/SocketSideEffectTest.swift
+++ b/Tests/TestSocketIO/SocketSideEffectTest.swift
@@ -511,5 +511,5 @@ class TestEngine : SocketEngineSpec {
     func flushWaitingForPostToWebSocket() { }
     func parseEngineData(_ data: Data) { }
     func parseEngineMessage(_ message: String) { }
-    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: @escaping (() -> ())?) { }
+    func write(_ msg: String, withType type: SocketEnginePacketType, withData data: [Data], completion: (() -> ())?) { }
 }


### PR DESCRIPTION
Improves performance, fixes https://github.com/socketio/socket.io-client-swift/issues/1118.