### PR TITLE
Call closeOutEngine to clean up after a ping timeout

### DIFF
--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -544,8 +544,7 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
 
         // Server is not responding
         if pongsMissed > pongsMissedMax {
-            client?.engineDidClose(reason: "Ping timeout")
-
+            closeOutEngine(reason: "Ping timeout")
             return
         }
 


### PR DESCRIPTION
Fixes #1156 

I've not touched any of the other instances of `client?.engineDidClose()`, so might be worth reviewing if any of those should be changed too.
