### PR TITLE
Adds missing character for url encoding

### DIFF
--- a/Source/SocketIO/Util/SocketExtensions.swift
+++ b/Source/SocketIO/Util/SocketExtensions.swift
@@ -38,7 +38,7 @@ extension Array {
 
 extension CharacterSet {
     static var allowedURLCharacterSet: CharacterSet {
-        return CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[]\" {}^").inverted
+        return CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[]\" {}^|").inverted
     }
 }
 

--- a/Tests/TestSocketIO/SocketEngineTest.swift
+++ b/Tests/TestSocketIO/SocketEngineTest.swift
@@ -87,11 +87,11 @@ class SocketEngineTest: XCTestCase {
         XCTAssertEqual(engine.urlWebSocket.query, "transport=websocket&created=2016-05-04T18%3A31%3A15%2B0200")
 
         engine.connectParams = [
-            "forbidden": "!*'();:@&=+$,/?%#[]\" {}^"
+            "forbidden": "!*'();:@&=+$,/?%#[]\" {}^|"
         ]
 
-        XCTAssertEqual(engine.urlPolling.query, "transport=polling&b64=1&forbidden=%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23%5B%5D%22%20%7B%7D%5E")
-        XCTAssertEqual(engine.urlWebSocket.query, "transport=websocket&forbidden=%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23%5B%5D%22%20%7B%7D%5E")
+        XCTAssertEqual(engine.urlPolling.query, "transport=polling&b64=1&forbidden=%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23%5B%5D%22%20%7B%7D%5E%7C")
+        XCTAssertEqual(engine.urlWebSocket.query, "transport=websocket&forbidden=%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23%5B%5D%22%20%7B%7D%5E%7C")
     }
 
     func testBase64Data() {


### PR DESCRIPTION
Fixes same issue as in https://github.com/socketio/socket.io-client-swift/issues/894 but for '|' character
