### PR TITLE
Added client emit methods with array parameters

### DIFF
--- a/Source/SocketIO/Client/SocketIOClient.swift
+++ b/Source/SocketIO/Client/SocketIOClient.swift
@@ -212,6 +212,19 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
     open func emit(_ event: String, _ items: SocketData..., completion: (() -> ())? = nil)  {
+        emit(event, items, completion: completion)
+    }
+    
+    /// Send an event to the server, with optional data items and optional write completion handler.
+    ///
+    /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
+    /// will be emitted. The structure of the error data is `[eventName, items, theError]`
+    ///
+    /// - parameter event: The event to send.
+    /// - parameter items: The items to send with this event. May be left out.
+    /// - parameter completion: Callback called on transport write completion.
+    open func emit(_ event: String, _ items: [SocketData], completion: (() -> ())?) {
+        
         do {
             emit([event] + (try items.map({ try $0.socketRepresentation() })), completion: completion)
         } catch {
@@ -242,6 +255,30 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     /// - parameter items: The items to send with this event. May be left out.
     /// - returns: An `OnAckCallback`. You must call the `timingOut(after:)` method before the event will be sent.
     open func emitWithAck(_ event: String, _ items: SocketData...) -> OnAckCallback {
+        emitWithAck(event, items)
+    }
+    
+    /// Sends a message to the server, requesting an ack.
+    ///
+    /// **NOTE**: It is up to the server send an ack back, just calling this method does not mean the server will ack.
+    /// Check that your server's api will ack the event being sent.
+    ///
+    /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
+    /// will be emitted. The structure of the error data is `[eventName, items, theError]`
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// socket.emitWithAck("myEvent", 1).timingOut(after: 1) {data in
+    ///     ...
+    /// }
+    /// ```
+    ///
+    /// - parameter event: The event to send.
+    /// - parameter items: The items to send with this event. May be left out.
+    /// - returns: An `OnAckCallback`. You must call the `timingOut(after:)` method before the event will be sent.
+    open func emitWithAck(_ event: String, _ items: [SocketData]) -> OnAckCallback {
+        
         do {
             return createOnAck([event] + (try items.map({ try $0.socketRepresentation() })))
         } catch {

--- a/Source/SocketIO/Client/SocketIOClient.swift
+++ b/Source/SocketIO/Client/SocketIOClient.swift
@@ -212,7 +212,7 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
     open func emit(_ event: String, _ items: SocketData..., completion: (() -> ())? = nil)  {
-        emit(event, items, completion: completion)
+        emit(event, with: items, completion: completion)
     }
     
     /// Send an event to the server, with optional data items and optional write completion handler.
@@ -223,7 +223,7 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     /// - parameter event: The event to send.
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
-    open func emit(_ event: String, _ items: [SocketData], completion: (() -> ())?) {
+    open func emit(_ event: String, with items: [SocketData], completion: (() -> ())?) {
         
         do {
             emit([event] + (try items.map({ try $0.socketRepresentation() })), completion: completion)
@@ -255,7 +255,7 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     /// - parameter items: The items to send with this event. May be left out.
     /// - returns: An `OnAckCallback`. You must call the `timingOut(after:)` method before the event will be sent.
     open func emitWithAck(_ event: String, _ items: SocketData...) -> OnAckCallback {
-        emitWithAck(event, items)
+        emitWithAck(event, with: items)
     }
     
     /// Sends a message to the server, requesting an ack.
@@ -277,7 +277,7 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     /// - parameter event: The event to send.
     /// - parameter items: The items to send with this event. May be left out.
     /// - returns: An `OnAckCallback`. You must call the `timingOut(after:)` method before the event will be sent.
-    open func emitWithAck(_ event: String, _ items: [SocketData]) -> OnAckCallback {
+    open func emitWithAck(_ event: String, with items: [SocketData]) -> OnAckCallback {
         
         do {
             return createOnAck([event] + (try items.map({ try $0.socketRepresentation() })))

--- a/Source/SocketIO/Client/SocketIOClientSpec.swift
+++ b/Source/SocketIO/Client/SocketIOClientSpec.swift
@@ -116,7 +116,7 @@ public protocol SocketIOClientSpec : AnyObject {
     /// - parameter event: The event to send.
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
-    func emit(_ event: String, _ items: [SocketData], completion: (() -> ())?)
+    func emit(_ event: String, with items: [SocketData], completion: (() -> ())?)
 
     /// Call when you wish to tell the server that you've received the event for `ack`.
     ///
@@ -164,7 +164,7 @@ public protocol SocketIOClientSpec : AnyObject {
     /// - parameter event: The event to send.
     /// - parameter items: The items to send with this event. May be left out.
     /// - returns: An `OnAckCallback`. You must call the `timingOut(after:)` method before the event will be sent.
-    func emitWithAck(_ event: String, _ items: [SocketData]) -> OnAckCallback
+    func emitWithAck(_ event: String, with items: [SocketData]) -> OnAckCallback
 
     /// Called when socket.io has acked one of our emits. Causes the corresponding ack callback to be called.
     ///

--- a/Source/SocketIO/Client/SocketIOClientSpec.swift
+++ b/Source/SocketIO/Client/SocketIOClientSpec.swift
@@ -107,6 +107,16 @@ public protocol SocketIOClientSpec : AnyObject {
     /// - parameter items: The items to send with this event. May be left out.
     /// - parameter completion: Callback called on transport write completion.
     func emit(_ event: String, _ items: SocketData..., completion: (() -> ())?)
+    
+    /// Send an event to the server, with optional data items and optional write completion handler.
+    ///
+    /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
+    /// will be emitted. The structure of the error data is `[eventName, items, theError]`
+    ///
+    /// - parameter event: The event to send.
+    /// - parameter items: The items to send with this event. May be left out.
+    /// - parameter completion: Callback called on transport write completion.
+    func emit(_ event: String, _ items: [SocketData], completion: (() -> ())?)
 
     /// Call when you wish to tell the server that you've received the event for `ack`.
     ///
@@ -134,6 +144,27 @@ public protocol SocketIOClientSpec : AnyObject {
     /// - parameter items: The items to send with this event. May be left out.
     /// - returns: An `OnAckCallback`. You must call the `timingOut(after:)` method before the event will be sent.
     func emitWithAck(_ event: String, _ items: SocketData...) -> OnAckCallback
+    
+    /// Sends a message to the server, requesting an ack.
+    ///
+    /// **NOTE**: It is up to the server send an ack back, just calling this method does not mean the server will ack.
+    /// Check that your server's api will ack the event being sent.
+    ///
+    /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
+    /// will be emitted. The structure of the error data is `[eventName, items, theError]`
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// socket.emitWithAck("myEvent", 1).timingOut(after: 1) {data in
+    ///     ...
+    /// }
+    /// ```
+    ///
+    /// - parameter event: The event to send.
+    /// - parameter items: The items to send with this event. May be left out.
+    /// - returns: An `OnAckCallback`. You must call the `timingOut(after:)` method before the event will be sent.
+    func emitWithAck(_ event: String, _ items: [SocketData]) -> OnAckCallback
 
     /// Called when socket.io has acked one of our emits. Causes the corresponding ack callback to be called.
     ///


### PR DESCRIPTION
This PR mitigates  an issue with your code emit methods syntax, which breaks the use of it if wrapped in another method.
Take for example a simple emit:

open func emit(_ event: String, _ items: SocketData..., completion: (() -> ())? = nil)  {
        do {
            emit([event] + (try items.map({ try $0.socketRepresentation() })), completion: completion)
        } catch {
            DefaultSocketLogger.Logger.error("Error creating socketRepresentation for emit: \(event), \(items)",
                                             type: logType)

            handleClientEvent(.error, data: [event, items, error])
        }
    }
You make use of variadic parameter, which is totally fine when used directly. For example socket.emit(event, arg1, arg2)

But if you wrap the call to this method:

func send(event: String, with arguments: [SocketTransferable]) {
       socket.emit(event, arguments)
}
the call send(event, arguments) will result in arguments being wrapped in array again because of how variadic parameters work. I can even write my method like this

func send(event: String, with arguments: SocketTransferable...) {
       socket.emit(event, arguments)
}
and still get errors from server for calls like send(event, arg1, arg2).

It adds methods overloads that accept parameters as array.