### PR TITLE
Add option to disableEventMessageParsing and receive messages as Strings

### DIFF
--- a/Source/SocketIO/Client/SocketIOClientOption.swift
+++ b/Source/SocketIO/Client/SocketIOClientOption.swift
@@ -77,6 +77,10 @@ public enum SocketIOClientOption : ClientOption {
     /// Used to pass in a custom logger.
     case logger(SocketLogger)
 
+    /// If passed `true`, event message data will not be parsed, and all message events will be received with
+    /// `event` value of `"rawMessage"`; listen with `socketClient.on("rawMessage") { ... }`
+    case disableEventMessageParsing(Bool)
+
     /// A custom path to socket.io. Only use this if the socket.io server is configured to look for this path.
     case path(String)
 
@@ -124,6 +128,8 @@ public enum SocketIOClientOption : ClientOption {
             description = "connectParams"
         case .cookies:
             description = "cookies"
+        case .disableEventMessageParsing:
+            description = "disableEventMessageParsing"
         case .extraHeaders:
             description = "extraHeaders"
         case .forceNew:
@@ -177,6 +183,8 @@ public enum SocketIOClientOption : ClientOption {
             value = params
         case let .cookies(cookies):
             value = cookies
+        case let .disableEventMessageParsing(disable):
+            value = disable
         case let .extraHeaders(headers):
             value = headers
         case let .forceNew(force):

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -79,6 +79,11 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
         }
     }
 
+    
+    /// If passed `true`, event message data will not be parsed, and all message events will be received with
+    /// `event` = "rawMessage"
+    public var disableEventMessageParsing = false
+    
     /// The engine for this manager.
     public var engine: SocketEngineSpec?
 
@@ -539,6 +544,8 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
     open func setConfigs(_ config: SocketIOClientConfiguration) {
         for option in config {
             switch option {
+            case let .disableEventMessageParsing(disable):
+                disableEventMessageParsing = disable
             case let .forceNew(new):
                 forceNew = new
             case let .handleQueue(queue):

--- a/Source/SocketIO/Parse/SocketParsable.swift
+++ b/Source/SocketIO/Parse/SocketParsable.swift
@@ -24,6 +24,9 @@ import Foundation
 
 /// Defines that a type will be able to parse socket.io-protocol messages.
 public protocol SocketParsable : AnyObject {
+    /// if `true`, disable parsing event payloads
+    var disableEventMessageParsing: Bool { get }
+
     // MARK: Methods
 
     /// Called when the engine has received some binary data that should be attached to a packet.
@@ -117,6 +120,10 @@ public extension SocketParsable where Self: SocketManagerSpec & SocketDataBuffer
         }
 
         var dataArray = String(message.utf16[message.utf16.index(reader.currentIndex, offsetBy: 1)...])!
+
+        if type == .event, self.disableEventMessageParsing {
+            return SocketPacket(type: type, data: ["rawMessage", dataArray], id: Int(idString) ?? -1, nsp: namespace, placeholders: placeholders)
+        }
 
         if (type == .error || type == .connect) && !dataArray.hasPrefix("[") && !dataArray.hasSuffix("]") {
             dataArray = "[" + dataArray + "]"


### PR DESCRIPTION
Hi @nuclearace! Not sure where I should direct this, but I had a need to parse my own messages (to use Decodables easily) and added a new config option: 
```
/// If passed `true`, event message data will not be parsed, and all message events will be received with
/// `event` value of `"rawMessage"`; listen with `socketClient.on("rawMessage") { ... }`
case disableEventMessageParsing(Bool)
```

If enabled, event messages are received like so:
```
socketClient.on("rawMessage") { data, ack in //data is [String] ... }
```
I'm sure there's a more beautiful way of implementing this, but I wanted to keep changes minimal. 

Upside for me is easy parsing into strongly typed objects using Codable

Any interest in merging?

## Example usage:

```
//receiving the rawMessage
socketClient.on("rawMessage") { data, ack in
	guard let s = data.first as? String, let data = s.data(using: .utf16) else { return }
	let decoder = JSONDecoder()
	let message = try! decoder.decode(Message.self, from: data)
	//do whatever!
}
```

## Parsing/Decoding:

```
enum Message: Decodable {
	case yellowAlert(YellowAlert)
	case redAlert(RedAlert)

	enum MessageType: String, Decodable {
		case yellowAlert
		case redAlert
	}

	init(from decoder: Decoder) throws {
		var values = try decoder.unkeyedContainer()
		let type = try values.decode(MessageType.self)
		switch type {
		case .yellowAlert:
			let payload = try values.decode(YellowAlert.self)
			self = .yellowAlert(payload)
		case .redAlert:
			let payload = try values.decode(RedAlert.self)
			self = .redAlert(payload)
		}
	}
	
	//Empty data types for demo purposes. You'd probably have some properties in real data.
	struct YellowAlert: Decodable { }
	struct RedAlert: Decodable { }
}
```
