### PR TITLE
Fix swift warnings

### DIFF
--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -751,7 +751,7 @@ extension SocketEngine {
         case .cancelled:
             wsConnected = false
             websocketDidDisconnect(error: EngineError.canceled)
-        case let .disconnected(reason, code):
+        case .disconnected(_, _):
             wsConnected = false
             websocketDidDisconnect(error: nil)
         case let .text(msg):

--- a/Source/SocketIO/Engine/SocketEngineSpec.swift
+++ b/Source/SocketIO/Engine/SocketEngineSpec.swift
@@ -27,7 +27,7 @@ import Foundation
 import Starscream
 
 /// Specifies a SocketEngine.
-public protocol SocketEngineSpec: class {
+public protocol SocketEngineSpec: AnyObject {
     // MARK: Properties
 
     /// The client for this engine.

--- a/Source/SocketIO/Manager/SocketManagerSpec.swift
+++ b/Source/SocketIO/Manager/SocketManagerSpec.swift
@@ -45,7 +45,7 @@ import Foundation
 /// To disconnect a socket and remove it from the manager, either call `SocketIOClient.disconnect()` on the socket,
 /// or call one of the `disconnectSocket` methods on this class.
 ///
-public protocol SocketManagerSpec : AnyObject, SocketEngineClient {
+public protocol SocketManagerSpec : SocketEngineClient {
     // MARK: Properties
 
     /// Returns the socket associated with the default namespace ("/").


### PR DESCRIPTION
In
```
case let .disconnected(reason, code):
```
both `reason` and `code` were not being used.

In
```
public protocol SocketEngineSpec: class {
```
you should be using `AnyObject` instead of `class`

In
```
public protocol SocketManagerSpec : AnyObject, SocketEngineClient {
```
`AnyObject` was redundant