### PR TITLE
FIX/ObjC-6.0.1-Bridge

### DIFF
--- a/Source/SocketIO/Client/SocketIOClient.swift
+++ b/Source/SocketIO/Client/SocketIOClient.swift
@@ -113,6 +113,9 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     open func connect(withPayload payload: [String: Any]? = nil) {
         connect(withPayload: payload, timeoutAfter: 0, withHandler: nil)
     }
+	@objc open func connect() {
+		connect(nil)
+	}
 
     /// Connect to the server. If we aren't connected after `timeoutAfter` seconds, then `withHandler` is called.
     ///
@@ -214,7 +217,9 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     open func emit(_ event: String, _ items: SocketData..., completion: (() -> ())? = nil)  {
         emit(event, with: items, completion: completion)
     }
-    
+    @objc open func emit(_ event: String, with items: Any)  {
+        emit(event, with: items as! [SocketData], completion: nil)
+    }
     /// Send an event to the server, with optional data items and optional write completion handler.
     ///
     /// If an error occurs trying to transform `items` into their socket representation, a `SocketClientEvent.error`
@@ -441,6 +446,7 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
     /// - parameter callback: The callback that will execute when this event is received.
     /// - returns: A unique id for the handler that can be used to remove it.
     @discardableResult
+	@objc
     open func on(_ event: String, callback: @escaping NormalCallback) -> UUID {
         DefaultSocketLogger.Logger.log("Adding handler for event: \(event)", type: logType)
 

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -51,7 +51,7 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
     // MARK: Properties
 
     /// The socket associated with the default namespace ("/").
-    public var defaultSocket: SocketIOClient {
+    @objc public var defaultSocket: SocketIOClient {
         return socket(forNamespace: "/")
     }
 

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -235,6 +235,7 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
     }
 
     /// Disconnects the manager and all associated sockets.
+	@objc
     open func disconnect() {
         DefaultSocketLogger.Logger.log("Manager closing", type: SocketManager.logType)
 


### PR DESCRIPTION
FIX for issue-1358:

Exposes following API to Obj-C:
SocketManager.defaultSocket
SocketManager.disconnect

SocketIOClient.on(callback:)
SocketIOClient.connect()
SocketIOClient.emit(with:)