### PR TITLE
Handling reconnect scenarios properly when socket is hung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ Socket.IO-Test-Server/node_modules/*
 .idea/
 docs/docsets/
 docs/undocumented.json
+
+.swiftpm

--- a/Source/SocketIO/Client/SocketIOClient.swift
+++ b/Source/SocketIO/Client/SocketIOClient.swift
@@ -150,7 +150,8 @@ open class SocketIOClient: NSObject, SocketIOClientSpec {
 
         manager.handleQueue.asyncAfter(deadline: DispatchTime.now() + timeoutAfter) {[weak self] in
             guard let this = self, this.status == .connecting || this.status == .notConnected else { return }
-
+            DefaultSocketLogger.Logger.log("Timeout: Socket not connected, so setting to disconnected", type: this.logType)
+            
             this.status = .disconnected
             this.leaveNamespace()
 

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -132,7 +132,7 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
     private(set) var reconnectAttempts = -1
 
     private var _config: SocketIOClientConfiguration
-    private var currentReconnectAttempt = 0
+    internal var currentReconnectAttempt = 0
     private var reconnecting = false
 
     // MARK: Initializers
@@ -186,9 +186,8 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
     ///
     /// Override if you wish to attach a custom `SocketEngineSpec`.
     open func connect() {
-        guard !status.active else {
+        if status == .connected || (status == .connecting && currentReconnectAttempt == 0) {
             DefaultSocketLogger.Logger.log("Tried connecting an already active socket", type: SocketManager.logType)
-
             return
         }
 

--- a/Tests/TestSocketIO/SocketAckManagerTest.swift
+++ b/Tests/TestSocketIO/SocketAckManagerTest.swift
@@ -28,7 +28,6 @@ class SocketAckManagerTest : XCTestCase {
 
     func testManagerTimeoutAck() {
         let callbackExpection = expectation(description: "Manager should timeout ack with noAck status")
-        let itemsArray = ["Hi", "ho"]
 
         func callback(_ items: [Any]) {
             XCTAssertEqual(items.count, 1, "Timed out ack should have one value")

--- a/Tests/TestSocketIO/SocketSideEffectTest.swift
+++ b/Tests/TestSocketIO/SocketSideEffectTest.swift
@@ -487,7 +487,7 @@ class TestEngine: SocketEngineSpec {
     private(set) var ws: WebSocket? = nil
     private(set) var version = SocketIOVersion.three
 
-    fileprivate var onConnect: (() -> ())?
+    internal var onConnect: (() -> ())?
 
     required init(client: SocketEngineClient, url: URL, options: [String: Any]?) {
         self.client = client


### PR DESCRIPTION
In situations where the socket connection is lost via a `SO_ERROR`, even though reconnect is enabled, the socket manager hangs the socket until a manual disconnect.  Symptom would be: the app would output something like the following:

```
2019-01-09 12:15:49.005630+0000 App [13746:3543026] [] nw_socket_handle_socket_event [C10.1:1] Socket SO_ERROR [61: Connection refused]
2019-01-09 12:15:49.016640+0000 App [13746:3543026] [] nw_socket_handle_socket_event [C10.2:1] Socket SO_ERROR [61: Connection refused]
```

Socket-IO would be logging the retry requests over and over again with the following log:
```
Tried connecting an already active socket
```

In this case, the `active` socket is hung, so a retry would never be attempted.  This condition can be simulated by running an app on a simulator while turning on Network Link Conditioner with 100% packet loss profile.  

This fix simply recycles the engine in the case that a `connecting` status has 1 or more retry attempts.  This seems to resolve the issue.