### PR TITLE
Fixed build phases order in target

### DIFF
--- a/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
+++ b/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
@@ -344,9 +344,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 572EF24B1B51F18A00EEBB58 /* Build configuration list for PBXNativeTarget "SocketIO" */;
 			buildPhases = (
+				572EF2351B51F18A00EEBB58 /* Headers */,
 				572EF2331B51F18A00EEBB58 /* Sources */,
 				572EF2341B51F18A00EEBB58 /* Frameworks */,
-				572EF2351B51F18A00EEBB58 /* Headers */,
 				572EF2361B51F18A00EEBB58 /* Resources */,
 			);
 			buildRules = (


### PR DESCRIPTION
See [Xcode 10's known issues](https://developer.apple.com/documentation/xcode-release-notes/build-system-release-notes-for-xcode-10) in the release notes:

> Targets with Copy Headers build phases ordered after Compile Sources build phases may fail to build and emit a diagnostic regarding build cycles. (39880168)
>*Workaround*: Arrange any Copy Headers build phases before Compile Sources build phases.

This has been an issue for nearly 4 years, and now with Xcode 13.3 it leads to `XCBBuildService` to crash consistently.