### PR TITLE
Add option to allow the use of URLSessionWebSocketTask in WebSocket client.

### DIFF
--- a/Source/SocketIO/Client/SocketIOClientOption.swift
+++ b/Source/SocketIO/Client/SocketIOClientOption.swift
@@ -108,6 +108,9 @@ public enum SocketIOClientOption : ClientOption {
     /// Sets an NSURLSessionDelegate for the underlying engine. Useful if you need to handle self-signed certs.
     case sessionDelegate(URLSessionDelegate)
 
+    /// If passed `false`, the WebSocket stream will be configured with the useCustomEngine `false`.
+    case useCustomEngine(Bool)
+
     /// The version of socket.io being used. This should match the server version. Default is 3.
     case version(SocketIOVersion)
 
@@ -160,6 +163,8 @@ public enum SocketIOClientOption : ClientOption {
             description = "sessionDelegate"
         case .enableSOCKSProxy:
             description = "enableSOCKSProxy"
+        case .useCustomEngine:
+            description = "customEngine"
         case .version:
             description = "version"
         }
@@ -212,6 +217,8 @@ public enum SocketIOClientOption : ClientOption {
         case let .sessionDelegate(delegate):
             value = delegate
         case let .enableSOCKSProxy(enable):
+            value = enable
+        case let .useCustomEngine(enable):
             value = enable
         case let.version(versionNum):
             value = versionNum

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -111,6 +111,9 @@ open class SocketEngine:
     /// The url for WebSockets.
     public private(set) var urlWebSocket = URL(string: "http://localhost/")!
 
+    /// When `false`, the WebSocket `stream` will be configured with the useCustomEngine `false`.
+    public private(set) var useCustomEngine = true
+
     /// The version of engine.io being used. Default is three.
     public private(set) var version: SocketIOVersion = .three
 
@@ -307,7 +310,7 @@ open class SocketEngine:
             includingCookies: session?.configuration.httpCookieStorage?.cookies(for: urlPollingWithSid)
         )
 
-        ws = WebSocket(request: req, certPinner: certPinner, compressionHandler: compress ? WSCompression() : nil)
+        ws = WebSocket(request: req, certPinner: certPinner, compressionHandler: compress ? WSCompression() : nil, useCustomEngine: useCustomEngine)
         ws?.callbackQueue = engineQueue
         ws?.delegate = self
 
@@ -624,6 +627,8 @@ open class SocketEngine:
                 self.compress = true
             case .enableSOCKSProxy:
                 self.enableSOCKSProxy = true
+            case let .useCustomEngine(enable):
+                self.useCustomEngine = enable
             case let .version(num):
                 version = num
             default:


### PR DESCRIPTION
Added a `useCustomEngine` case to `SocketIOClientOption`. The associated bool will be passed to the WebSocket initializer. I needed this option so that I could control if the WebSocket client would use the native URLSessionWebSocketTask instead of the "custom engine."