### PR TITLE
Typo in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ socket.on("currentAmount") {data, ack in
     guard let cur = data[0] as? Double else { return }
     
     socket.emitWithAck("canUpdate", cur).timingOut(after: 0) {data in
-        if data.first as? String ?? "passed" == SocketAckValue.noAck {
+        if data.first as? String ?? "passed" == SocketAckStatus.noAck {
             // Handle ack timeout 
         }
 


### PR DESCRIPTION
I'm trying this library out and I noticed Xcode giving me an error with "SocketAckValue" and after changing it to `.ack` it seems like it should be `SocketAckStatus.ack`.