### PR TITLE
fix never running timingOut due to weak self capture

### DIFF
--- a/Source/SocketIO/Ack/SocketAckEmitter.swift
+++ b/Source/SocketIO/Ack/SocketAckEmitter.swift
@@ -136,8 +136,8 @@ public final class OnAckCallback: NSObject {
 
         guard seconds != 0 else { return }
 
-        socket.manager?.handleQueue.asyncAfter(deadline: DispatchTime.now() + seconds) {[weak socket, weak self] in
-            guard let socket = socket, let `self` = self else { return }
+        socket.manager?.handleQueue.asyncAfter(deadline: DispatchTime.now() + seconds) {[weak socket] in
+            guard let socket = socket else { return }
 
             socket.ackHandlers.timeoutAck(self.ackNumber)
         }


### PR DESCRIPTION
Refer to: [this issue](https://github.com/socketio/socket.io-client-swift/issues/1462)
> Fixed [the timeOut callback function never running] by removing the weak self capture in the `timingOut` function. Not sure why self is lost in the first place, but retain cycles are not a problem since they are only temporary anyways with `asyncAfter(...) { }`