### PR TITLE
Improved websocket reconnection logic

### DIFF
--- a/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
+++ b/Socket.IO-Client-Swift.xcodeproj/project.pbxproj
@@ -70,7 +70,6 @@
 		1C686BD61F869AF1007D8627 /* SocketAckManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketAckManagerTest.swift; sourceTree = "<group>"; };
 		1C686BD71F869AF1007D8627 /* SocketParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketParserTest.swift; sourceTree = "<group>"; };
 		1C686BD81F869AF1007D8627 /* SocketNamespacePacketTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketNamespacePacketTest.swift; sourceTree = "<group>"; };
-		1C686BFE1F869E9D007D8627 /* SocketObjectiveCTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SocketObjectiveCTest.m; sourceTree = "<group>"; };
 		572EF2381B51F18A00EEBB58 /* SocketIO.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SocketIO.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		572EF23B1B51F18A00EEBB58 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		572EF23C1B51F18A00EEBB58 /* SocketIO.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SocketIO.h; sourceTree = "<group>"; };
@@ -87,7 +86,6 @@
 		DD52B078DB0A3C3D1BB507CD /* SocketIOClientOption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketIOClientOption.swift; sourceTree = "<group>"; };
 		DD52B09F7984E730513AB7E5 /* SocketAckManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketAckManager.swift; sourceTree = "<group>"; };
 		DD52B1D9BC4AE46D38D827DE /* SocketIOStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketIOStatus.swift; sourceTree = "<group>"; };
-		DD52B2C54A6ADF3371C13DCB /* SocketObjectiveCTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketObjectiveCTest.h; sourceTree = "<group>"; };
 		DD52B2D110F55723F82B108E /* SocketEnginePollable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketEnginePollable.swift; sourceTree = "<group>"; };
 		DD52B31D0E6815F5F10CEFB6 /* SocketParsable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketParsable.swift; sourceTree = "<group>"; };
 		DD52B471D780013E18DF9335 /* SocketExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketExtensions.swift; sourceTree = "<group>"; };
@@ -98,10 +96,8 @@
 		DD52B645273A873667BC2D43 /* SocketEngineSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketEngineSpec.swift; sourceTree = "<group>"; };
 		DD52B6DCCBBAC6BE9C22568D /* SocketEventHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketEventHandler.swift; sourceTree = "<group>"; };
 		DD52B7A9779A2E08075E5AAC /* SocketEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketEngine.swift; sourceTree = "<group>"; };
-		DD52B8396C7DEE7BFD6A985A /* ManagerObjectiveCTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ManagerObjectiveCTest.h; sourceTree = "<group>"; };
 		DD52BA1F41F2E4B3DC20260E /* SocketIOClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketIOClient.swift; sourceTree = "<group>"; };
 		DD52BA240D139F72633D4159 /* SocketStringReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketStringReader.swift; sourceTree = "<group>"; };
-		DD52BB5E907D283ACC31E17F /* ManagerObjectiveCTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ManagerObjectiveCTest.m; sourceTree = "<group>"; };
 		DD52BBAC5FAA7730D32CD5BF /* SocketMangerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketMangerTest.swift; sourceTree = "<group>"; };
 		DD52BCAF915A546288664346 /* SocketIOClientSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketIOClientSpec.swift; sourceTree = "<group>"; };
 		DD52BDC9E66AADA2CC5E8246 /* SocketTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketTypes.swift; sourceTree = "<group>"; };
@@ -161,23 +157,10 @@
 			path = Tests/TestSocketIO;
 			sourceTree = "<group>";
 		};
-		1C686BFD1F869E9D007D8627 /* TestSocketIOObjc */ = {
-			isa = PBXGroup;
-			children = (
-				1C686BFE1F869E9D007D8627 /* SocketObjectiveCTest.m */,
-				DD52BB5E907D283ACC31E17F /* ManagerObjectiveCTest.m */,
-				DD52B8396C7DEE7BFD6A985A /* ManagerObjectiveCTest.h */,
-				DD52B2C54A6ADF3371C13DCB /* SocketObjectiveCTest.h */,
-			);
-			name = TestSocketIOObjc;
-			path = Tests/TestSocketIOObjc;
-			sourceTree = "<group>";
-		};
 		572EF20D1B51F12F00EEBB58 = {
 			isa = PBXGroup;
 			children = (
 				1C686BD11F869AF1007D8627 /* TestSocketIO */,
-				1C686BFD1F869E9D007D8627 /* TestSocketIOObjc */,
 				6CA08A9B1D615C190061FD2A /* Frameworks */,
 				572EF21A1B51F16C00EEBB58 /* Products */,
 				572EF2391B51F18A00EEBB58 /* SocketIO */,

--- a/Source/SocketIO/Ack/SocketAckEmitter.swift
+++ b/Source/SocketIO/Ack/SocketAckEmitter.swift
@@ -131,15 +131,17 @@ public final class OnAckCallback: NSObject {
     public func timingOut(after seconds: Double, callback: @escaping AckCallback) {
         guard let socket = self.socket, ackNumber != -1 else { return }
 
+        let ackNumber = self.ackNumber
+
         socket.ackHandlers.addAck(ackNumber, callback: callback)
         socket.emit(items, ack: ackNumber, binary: binary)
 
         guard seconds != 0 else { return }
 
-        socket.manager?.handleQueue.asyncAfter(deadline: DispatchTime.now() + seconds) {[weak socket, weak self] in
-            guard let socket = socket, let `self` = self else { return }
+        socket.manager?.handleQueue.asyncAfter(deadline: DispatchTime.now() + seconds) {[weak socket] in
+            guard let socket = socket else { return }
 
-            socket.ackHandlers.timeoutAck(self.ackNumber)
+            socket.ackHandlers.timeoutAck(ackNumber)
         }
     }
 

--- a/Source/SocketIO/Client/SocketIOClientOption.swift
+++ b/Source/SocketIO/Client/SocketIOClientOption.swift
@@ -114,6 +114,15 @@ public enum SocketIOClientOption : ClientOption {
     /// The version of socket.io being used. This should match the server version. Default is 3.
     case version(SocketIOVersion)
 
+    /// How long to wait for the web socket to connect before timing out. Default is 10.
+    case wsConnectionTimeout(TimeInterval)
+
+    /// Websocket event name to use as a heartbeat mechanism.
+    case wsHeartbeatEventName(String)
+
+    /// How frequently to send heartbeat events to the server. Only valid if `wsHeartbeatEventName` is set. Default is 10.
+    case wsHeartbeatInterval(TimeInterval)
+
     // MARK: Properties
 
     /// The description of this option.
@@ -167,6 +176,12 @@ public enum SocketIOClientOption : ClientOption {
             description = "customEngine"
         case .version:
             description = "version"
+        case .wsConnectionTimeout:
+            description = "wsConnectionTimeout"
+        case .wsHeartbeatEventName:
+            description = "wsHeartbeatEventName"
+        case .wsHeartbeatInterval:
+            description = "wsHeartbeatInterval"
         }
 
         return description
@@ -222,6 +237,12 @@ public enum SocketIOClientOption : ClientOption {
             value = enable
         case let.version(versionNum):
             value = versionNum
+        case let .wsConnectionTimeout(timeout):
+            value = timeout
+        case let .wsHeartbeatEventName(eventName):
+            value = eventName
+        case let .wsHeartbeatInterval(interval):
+            value = interval
         }
 
         return value

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -827,6 +827,12 @@ extension SocketEngine {
             parseEngineData(data)
         case let .viabilityChanged(isViable):
             DefaultSocketLogger.Logger.log("viabilityChanged - isViable: \(isViable)", type: SocketEngine.logType)
+        case let .reconnectSuggested(isSuggested):
+            DefaultSocketLogger.Logger.log("reconnectSuggested - isSuggested: \(isSuggested)", type: SocketEngine.logType)
+
+            if isSuggested {
+                closeOutEngine(reason: "Better path available")
+            }
         case _:
             break
         }

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -308,6 +308,7 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
     }
 
     private func _engineDidClose(reason: String) {
+        DefaultSocketLogger.Logger.log("engineDidClose: \(reason)", type: SocketManager.logType)
         waitingPackets.removeAll()
 
         if status != .disconnected {
@@ -489,7 +490,7 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
         DefaultSocketLogger.Logger.log("Starting reconnect", type: SocketManager.logType)
 
         // Set status to connecting and emit reconnect for all sockets
-        forAll {socket in
+        forAll { socket in
             guard socket.status == .connected else { return }
 
             socket.setReconnecting(reason: reason)
@@ -507,7 +508,7 @@ open class SocketManager: NSObject, SocketManagerSpec, SocketParsable, SocketDat
 
         DefaultSocketLogger.Logger.log("Trying to reconnect", type: SocketManager.logType)
 
-        forAll {socket in
+        forAll { socket in
             guard socket.status == .connecting else { return }
 
             socket.handleClientEvent(.reconnectAttempt, data: [(reconnectAttempts - currentReconnectAttempt)])

--- a/Source/SocketIO/Util/SocketExtensions.swift
+++ b/Source/SocketIO/Util/SocketExtensions.swift
@@ -89,6 +89,12 @@ extension Dictionary where Key == String, Value == Any {
             return .enableSOCKSProxy(enable)
         case let ("version", version as Int):
             return .version(SocketIOVersion(rawValue: version) ?? .three)
+        case let ("wsConnectionTimeout", timeout as TimeInterval):
+            return .wsConnectionTimeout(timeout)
+        case let ("wsHeartbeatEventName", eventName as String):
+            return .wsHeartbeatEventName(eventName)
+        case let ("wsHeartbeatInterval", interval as TimeInterval):
+            return .wsHeartbeatInterval(interval)
         case _:
             return nil
         }


### PR DESCRIPTION
This PR contains two primary improvements:

First, a configurable timeout was added for when the `SocketEngine`
initially attempts to establish a connection via websocket. Without this
timeout in place, the `SocketEngineClient` (read: the `SocketManager`)
doesn't get properly informed of the hanging connection and wastes its
reconnect attempts. 10 seconds was chosen as the default timeout based
on extensive testing with poor network conditions, but can be modified
based on the requirements of the app using this library if necessary.

Second, a configurable heartbeat mechanism was added to the
`SocketEngine` implementation. This allows consumers of this library to
specify a socket endpoint to use for heartbeat requests. Since
Socket.IO's ping/pong implementation was reversed in v3+ of the
protocol, clients no longer have a liveness check built in. The ping and
pong events are reserved for Socket.IO, so this allows you to specify a
different (hopefully very simple and very performant) event that can be
used for the same purpose.

Instead of mirroring the ping/pong logic exactly, the heartbeat is
designed to only beat when other packets aren't being transmitted.
Meaning, if your socket is already actively receiving data, there's no
reason to perform a heartbeat, since it's obviously connected. This is
done to reduce the load on the server.