### PR TITLE
Bump minimum deployment target to iOS 12 to match Starscream dependency

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/socketio/socket.io-client-swift"
   s.license      = { :type => 'MIT' }
   s.author       = { "Erik" => "nuclear.ace@gmail.com" }
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.13'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '5.0'


### PR DESCRIPTION
Currently there is an error when compiling for release:
```
Compiling for iOS 11.0, but module 'Starscream' has a minimum deployment target of iOS 12.0
```

This pull request addresses this error by bumping the minimum deployment target to match Starscream.