### PR TITLE
Use correct default socket path. Use native engine of StarScream

### DIFF
--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -105,7 +105,7 @@ open class SocketEngine: NSObject, WebSocketDelegate, URLSessionDelegate,
     public private(set) var sid = ""
 
     /// The path to engine.io.
-    public private(set) var socketPath = "/engine.io/"
+    public private(set) var socketPath = "/socket.io/"
 
     /// The url for polling.
     public private(set) var urlPolling = URL(string: "http://localhost/")!
@@ -114,7 +114,7 @@ open class SocketEngine: NSObject, WebSocketDelegate, URLSessionDelegate,
     public private(set) var urlWebSocket = URL(string: "http://localhost/")!
 
     /// When `false`, the WebSocket `stream` will be configured with the useCustomEngine `false`.
-    public private(set) var useCustomEngine = true
+    public private(set) var useCustomEngine = false
 
     /// The version of engine.io being used. Default is three.
     public private(set) var version: SocketIOVersion = .three
@@ -750,6 +750,8 @@ extension SocketEngine {
     ///   - event: WS Event
     ///   - _:
     public func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocketClient) {
+        DefaultSocketLogger.Logger.log("didReceive \(event)", type: "SocketEngine")
+
         switch event {
         case let .connected(headers):
             wsConnected = true


### PR DESCRIPTION
I've been debugging in the past 2 days why the socket.io is not working connecting with our backend. Android was working fine, but iOS seems to be stuck with no explanation. I managed to get it working and some of the reasons are these:
1. the default socket.io path is encoded to `engine.io` whereas the correct one is `socket.io` as specified in the docs. This definely made a lot of people not understand what is happening and probably the issues opened in the past few days, can relate to this.
2. from what I tested, the default implementation of starscream uses custom ws engine by default. however, this doesn't seem to work great with our backend and using the native engine seems to be doing a great job.
3. there is no logging of the WS events and error logs are not handeld at all. For this reason, we had no idea that we were getting a 404 when the upgrade request was being made. 