### PR TITLE
Update Starscream to v4.0.8

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" ~> 4.0.6
+github "daltoniam/Starscream" ~> 4.0.8

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" "4.0.6"
+github "daltoniam/Starscream" "4.0.8"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream",
         "state": {
           "branch": null,
-          "revision": "ac6c0fc9da221873e01bd1a0d4818498a71eef33",
-          "version": "4.0.6"
+          "revision": "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+          "version": "4.0.8"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "SocketIO", targets: ["SocketIO"])
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream", .exactItem("4.0.6")),
+        .package(url: "https://github.com/daltoniam/Starscream", .exactItem("4.0.8")),
     ],
     targets: [
         .target(name: "SocketIO", dependencies: ["Starscream"]),

--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
       'SWIFT_VERSION' => '5.4'
   }
   s.source_files  = "Source/SocketIO/**/*.swift", "Source/SocketIO/*.swift"
-  s.dependency "Starscream", "~> 4.0.6"
+  s.dependency "Starscream", "~> 4.0.8"
 end


### PR DESCRIPTION
ref https://github.com/socketio/socket.io-client-swift/issues/1478

We need to update the version of Starscream to support the Privacy Manifest.

https://github.com/daltoniam/Starscream/compare/4.0.6...4.0.8

This pull request is a redo of https://github.com/socketio/socket.io-client-swift/pull/1486. 

I have reconfirmed the operation, and it appears to be functioning correctly in my application( socket.io 2 servers ).