### PR TITLE
Fix the issue where it takes over 60 seconds to close the socket after a network disconnection

### DIFF
--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -761,6 +761,12 @@ extension SocketEngine {
         case .disconnected(_, _):
             wsConnected = false
             websocketDidDisconnect(error: nil)
+        case .viabilityChanged(false):
+            wsConnected = false
+            websocketDidDisconnect(error: nil)
+        case .peerClosed:
+            wsConnected = false
+            websocketDidDisconnect(error: nil)
         case let .text(msg):
             parseEngineMessage(msg)
         case let .binary(data):


### PR DESCRIPTION
Fix the issue where it takes over 60 seconds to close the socket after a network disconnection, and the problem where the server-side socket takes over 30 seconds to close when the server ends a connection