### PR TITLE
Support Privacy Manifest: bump Starscream package version to upToNextMajor 4.0.8

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream",
         "state": {
           "branch": null,
-          "revision": "ac6c0fc9da221873e01bd1a0d4818498a71eef33",
-          "version": "4.0.6"
+          "revision": "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+          "version": "4.0.8"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "SocketIO", targets: ["SocketIO"])
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream", .exactItem("4.0.6")),
+        .package(url: "https://github.com/daltoniam/Starscream", .upToNextMajor(from: "4.0.8")),
     ],
     targets: [
         .target(name: "SocketIO", dependencies: ["Starscream"]),


### PR DESCRIPTION
This PR solves the impossibility of **publishing** iOS applications due to the [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) rule which is now mandatory.

The problem is that **socket.io** is pointing to **4.0.6** **Starscream**, but Starscream started supporting the Privacy Manifest policy from **4.0.8**.

This PR updates its minimum version from 4.0.6 to `4.0.8`.

I already published my application to the App Store with this change without any issues.


⭐️ Eventually, instead of using `upToNextMajor` you can use `exact`. It's up to you.