### PR TITLE
Adding an option to ignore httpCookieStorage Cookies

### DIFF
--- a/Source/SocketIO/Client/SocketIOClientOption.swift
+++ b/Source/SocketIO/Client/SocketIOClientOption.swift
@@ -48,6 +48,9 @@ public enum SocketIOClientOption : ClientOption {
 
     /// An array of cookies that will be sent during the initial connection.
     case cookies([HTTPCookie])
+    
+    /// if `false` cookies from cookieStorage will be ignored.
+    case useCookieStorageCookies(Bool)
 
     /// Any extra HTTP headers that should be sent during the initial connection.
     case extraHeaders([String: String])
@@ -127,6 +130,8 @@ public enum SocketIOClientOption : ClientOption {
             description = "connectParams"
         case .cookies:
             description = "cookies"
+        case .useCookieStorageCookies:
+            description = "useCookieStorageCookies"
         case .extraHeaders:
             description = "extraHeaders"
         case .forceNew:
@@ -182,6 +187,8 @@ public enum SocketIOClientOption : ClientOption {
             value = params
         case let .cookies(cookies):
             value = cookies
+        case let .useCookieStorageCookies(useCookieStorageCookies):
+            value = useCookieStorageCookies
         case let .extraHeaders(headers):
             value = headers
         case let .forceNew(force):

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -77,6 +77,10 @@ open class SocketEngine: NSObject, WebSocketDelegate, URLSessionDelegate,
 
     /// An array of HTTPCookies that are sent during the connection.
     public private(set) var cookies: [HTTPCookie]?
+    
+    /// it `true` the engine will add all cookies from cookieStorage for the connectionURL
+    /// if you need to manual manage all cookies set this to `false`
+    public private(set) var useCookieStorageCookies: Bool = true
 
     /// When `true`, the engine is in the process of switching to WebSockets.
     ///
@@ -307,9 +311,11 @@ open class SocketEngine: NSObject, WebSocketDelegate, URLSessionDelegate,
     private func createWebSocketAndConnect() {
         var req = URLRequest(url: urlWebSocketWithSid)
 
+        var cookies:[HTTPCookie] = useCookieStorageCookies ? session?.configuration.httpCookieStorage?.cookies(for: urlPollingWithSid) ?? [] : []
+        
         addHeaders(
             to: &req,
-            includingCookies: session?.configuration.httpCookieStorage?.cookies(for: urlPollingWithSid)
+            includingCookies: cookies
         )
 
         ws = WebSocket(request: req, certPinner: certPinner, compressionHandler: compress ? WSCompression() : nil, useCustomEngine: useCustomEngine)
@@ -605,6 +611,8 @@ open class SocketEngine: NSObject, WebSocketDelegate, URLSessionDelegate,
                 connectParams = params
             case let .cookies(cookies):
                 self.cookies = cookies
+            case let .useCookieStorageCookies(useCookieStorageCookies):
+                self.useCookieStorageCookies = useCookieStorageCookies
             case let .extraHeaders(headers):
                 extraHeaders = headers
             case let .sessionDelegate(delegate):


### PR DESCRIPTION
In some specific cases where the backed validate the cookies that will be sent we need to have more strict control to cookies that the app will be used in the websocket request.